### PR TITLE
Adds support for generic Docker Registries, Fixes Broken Publish-GitHubRelease tests

### DIFF
--- a/src/modules/AmidoBuild/exported/Build-DockerImage.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.Tests.ps1
@@ -82,6 +82,13 @@ Describe "Build-DockerImage" {
 
             Should -Invoke -CommandName Write-Error -Times 1
         }
+
+        It "must error if trying to push to a generic registry and do not specify DOCKER_USERNAME or DOCKER_PASSWORD env vars" {
+
+            Build-DockerImage -Name unittests -Push -Generic
+
+            Should -Invoke -CommandName Write-Error -Times 1
+        }
     }
 
     Context "Build without push" {

--- a/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
@@ -63,7 +63,7 @@ function Build-DockerImage() {
     }
 
     if ([string]::IsNullOrEmpty($tag)) {
-        $tag = "workstation-0.0.1"
+        $tag = "0.0.1-workstation"
         Write-Information -MessageData ("No tag has been specified for the image, a default one has been set: {0}" -f $tag)
     }
 

--- a/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
@@ -50,7 +50,14 @@ function Build-DockerImage() {
         )]
         [switch]
         # Push the image to the specified registry
-        $push
+        $push,
+        [Parameter(
+            ParameterSetName="push"
+        )]
+        [switch]
+        # Push the image to a generic, non-Azure registry.
+        # Make sure you have env vars for DOCKER_PASSWORD and DOCKER_USERNAME.
+        $generic
 
     )
 
@@ -74,6 +81,10 @@ function Build-DockerImage() {
         return
     }
 
+    if ($generic.IsPresent -and ([string]::IsNullOrEmpty($env:DOCKER_USERNAME) -Or [string]::IsNullOrEmpty($env:DOCKER_PASSWORD))) {
+        Write-Error -Message "Pushing to a generic registry requires environment variables DOCKER_USERNAME and DOCKER_PASSWORD to be set"
+        return
+    }
     # Create an array to store the arguments to pass to docker
     $arguments = @()
     $arguments += $buildArgs
@@ -97,25 +108,30 @@ function Build-DockerImage() {
     # Proceed if a registry has been specified
     if (![String]::IsNullOrEmpty($registry) -and $push.IsPresent -and !(Test-Path -Path env:\NO_PUSH)) {
 
-        # Ensure that the module is available and loaded
-        $moduleName = "Az.ContainerRegistry"
-        $module = Get-Module -ListAvailable -Name $moduleName
-        if ([string]::IsNullOrEmpty($module)) {
-            Write-Error -Message ("{0} module is not available" -f $moduleName)
-            exit 2
+        if (!$generic) {
+            # Ensure that the module is available and loaded
+            $moduleName = "Az.ContainerRegistry"
+            $module = Get-Module -ListAvailable -Name $moduleName
+            if ([string]::IsNullOrEmpty($module)) {
+                Write-Error -Message ("{0} module is not available" -f $moduleName)
+                exit 2
+            } else {
+                Import-Module -Name $moduleName
+            }
+
+            # Login to azure
+            Connect-Azure
+
+            # Get the credentials for the registry
+            $creds = Get-AzContainerRegistryCredential -Name $registry -ResourceGroup $group
+        
+            $cmd = "docker login {0} -u {1} -p {2}" -f $registry, $creds.UserName, $creds.Password
+
         } else {
-            Import-Module -Name $moduleName
+            $cmd = "docker login {0} -u {1} -p {2}" -f $registry, $env:DOCKER_USERNAME, $env:DOCKER_PASSWORD
         }
-
-        # Login to azure
-        Connect-Azure
-
-        # Get the credentials for the registry
-        $creds = Get-AzContainerRegistryCredential -Name $registry -ResourceGroup $group
-
         # Run command to login to the docker registry to do the push
         # The Invoke-External function will need to be updated to obfruscate sensitive information
-        $cmd = "docker login {0} -u {1} -p {2}" -f $registry, $creds.Username, $creds.Password
         Invoke-External -Command $cmd
 
         if ($LASTEXITCODE -ne 0) {

--- a/src/modules/AmidoBuild/exported/Publish-GitHubRelease.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Publish-GitHubRelease.Tests.ps1
@@ -16,6 +16,7 @@ Describe "Publish-GitHubRelease" {
             # Mock commands
             Mock -CommandName Write-Error -MockWith {} -ParameterFilter { $Message.ToLower().Contains("version") }
             Mock -CommandName Write-Error -MockWith {} -ParameterFilter { $Message.ToLower().Contains("unable to call api")}
+            Mock -CommandName Write-Information -MockWith {} -ParameterFilter { $Message.ToLower().Contains("publishrelease parameter not specified")}
 
             Mock -CommandName Invoke-WebRequest -MockWith { throw "Unable to call API" } -ParameterFilter { $Uri.AbsoluteUri.ToLower().Contains("api.github.com/repos/amido/pester")}
         }
@@ -34,9 +35,23 @@ Describe "Publish-GitHubRelease" {
             Remove-Item -Path $testFolder -Recurse -Force
         }
 
-        It "if parameters have not been set" {
+        It "if publishRelease parameter has not been set" {
 
             Publish-GitHubRelease
+
+            Should -Invoke -CommandName Write-Information -Times 1
+        }
+
+        It "if publishRelease parameter has been set to false" {
+
+            Publish-GitHubRelease -publishRelease $false
+
+            Should -Invoke -CommandName Write-Information -Times 1
+        }
+
+        It "if parameters have not been set" {
+
+            Publish-GitHubRelease -publishRelease $true
 
             Should -Invoke -CommandName Write-Error -Times 1
         }
@@ -50,6 +65,7 @@ Describe "Publish-GitHubRelease" {
                 apiKey = "1245356"
                 repository = "pester"
                 artifactsDir = $testfolder
+                publishRelease = $true
             }
 
             Publish-GitHubRelease @splat
@@ -100,6 +116,7 @@ Describe "Publish-GitHubRelease" {
                 apiKey = "1245356"
                 repository = "pester"
                 artifactsDir = $testfolder
+                publishRelease = $true
             }
 
             Publish-GitHubRelease @splat

--- a/src/modules/AmidoBuild/exported/Publish-GitHubRelease.ps1
+++ b/src/modules/AmidoBuild/exported/Publish-GitHubRelease.ps1
@@ -73,7 +73,7 @@ function Publish-GitHubRelease() {
     # Check whether to actually create the release
     # TODO: export this to separate configuration cmdlet
     
-    if ([string]::IsNullOrEmpty($env:PUBLISH_RELEASE)) {
+    if ([string]::IsNullOrEmpty($env:PUBLISH_RELEASE) -and !$publishRelease) {
         $publishRelease = $false
     } else {
         $publishRelease = $true

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -1,6 +1,6 @@
 
 
-import:
+#import:
 # Contexts
 # - https://raw.githubusercontent.com/amido/stacks-pipeline-templates/875d45a6e44aeca0ff51db864a24631a81b2cd2c/taskctl/contexts.yml
 

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -2,88 +2,88 @@
 
 import:
 # Contexts
-- https://raw.githubusercontent.com/amido/stacks-pipeline-templates/875d45a6e44aeca0ff51db864a24631a81b2cd2c/taskctl/contexts.yml
+# - https://raw.githubusercontent.com/amido/stacks-pipeline-templates/875d45a6e44aeca0ff51db864a24631a81b2cd2c/taskctl/contexts.yml
 
-# contexts:
-#   docsenv:
-#     executable:
-#       bin: docker
-#       args:
-#         - run
-#         - --rm
-#         - -v
-#         - ${PWD}:/app
-#         - -e
-#         - PSModulePath=/app/src/modules        
-#         - -w
-#         - /app
-#         - russellseymour/pandoc-asciidoctor
-#         - pwsh
-#         - -NoProfile
-#         - -Command
-#     quote: "'"
+contexts:
+  docsenv:
+    executable:
+      bin: docker
+      args:
+        - run
+        - --rm
+        - -v
+        - ${PWD}:/app
+        - -e
+        - PSModulePath=/app/src/modules        
+        - -w
+        - /app
+        - russellseymour/pandoc-asciidoctor
+        - pwsh
+        - -NoProfile
+        - -Command
+    quote: "'"
 
-#   powershell_test:
-#     executable:
-#       bin: docker
-#       args:
-#         - run
-#         - --rm
-#         - -v
-#         - ${PWD}:/app
-#         - -v
-#         - /var/run/docker.sock:/var/run/docker.sock
-#         - -e
-#         - PSModulePath=/app/src/modules
-#         - -w
-#         - /app
-#         - russellseymour/runner-pwsh:0.0.4
-#         - pwsh
-#         - -NoProfile
-#         - -Command
-#     quote: "'"
+  powershell_test:
+    executable:
+      bin: docker
+      args:
+        - run
+        - --rm
+        - -v
+        - ${PWD}:/app
+        - -v
+        - /var/run/docker.sock:/var/run/docker.sock
+        - -e
+        - PSModulePath=/app/src/modules
+        - -w
+        - /app
+        - russellseymour/runner-pwsh:0.0.4
+        - pwsh
+        - -NoProfile
+        - -Command
+    quote: "'"
 
-#   powershell:
-#     executable:
-#       bin: docker
-#       args:
-#         - run
-#         - --env-file envfile
-#         - --rm
-#         - -v
-#         - ${PWD}:/app
-#         - -v
-#         - /var/run/docker.sock:/var/run/docker.sock
-#         - -e
-#         - PSModulePath=/app/src/modules
-#         - -w
-#         - /app
-#         - russellseymour/runner-pwsh:0.0.4
-#         - pwsh
-#         - -NoProfile
-#         - -Command
-#     quote: "'"
-#     before: env | grep -v PATH > envfile
+  powershell:
+    executable:
+      bin: docker
+      args:
+        - run
+        - --env-file envfile
+        - --rm
+        - -v
+        - ${PWD}:/app
+        - -v
+        - /var/run/docker.sock:/var/run/docker.sock
+        - -e
+        - PSModulePath=/app/src/modules
+        - -w
+        - /app
+        - russellseymour/runner-pwsh:0.0.4
+        - pwsh
+        - -NoProfile
+        - -Command
+    quote: "'"
+    before: env | grep -v PATH > envfile
 
-#   dotnet:
-#     executable:
-#       bin: docker
-#       args:
-#         - run
-#         - --rm
-#         - -v
-#         - ${PWD}:/app
-#         - -v
-#         - /var/run/docker.sock:/var/run/docker.sock
-#         - -e
-#         - PSModulePath=/app/src/modules
-#         - -w
-#         - /app
-#         - russellseymour/runner-pwsh-dotnet:0.0.3
-#         - pwsh
-#         - -NoProfile
-#         - -Command
-#     quote: "'"    
+  dotnet:
+    executable:
+      bin: docker
+      args:
+        - run
+        - --rm
+        - -v
+        - ${PWD}:/app
+        - -v
+        - /var/run/docker.sock:/var/run/docker.sock
+        - -e
+        - PSModulePath=/app/src/modules
+        - -w
+        - /app
+        - russellseymour/runner-pwsh-dotnet:0.0.3
+        - pwsh
+        - -NoProfile
+        - -Command
+    quote: "'"    
 
 tasks:
 

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -1,84 +1,89 @@
 
-contexts:
-  docsenv:
-    executable:
-      bin: docker
-      args:
-        - run
-        - --rm
-        - -v
-        - ${PWD}:/app
-        - -e
-        - PSModulePath=/app/src/modules        
-        - -w
-        - /app
-        - russellseymour/pandoc-asciidoctor
-        - pwsh
-        - -NoProfile
-        - -Command
-    quote: "'"
 
-  powershell_test:
-    executable:
-      bin: docker
-      args:
-        - run
-        - --rm
-        - -v
-        - ${PWD}:/app
-        - -v
-        - /var/run/docker.sock:/var/run/docker.sock
-        - -e
-        - PSModulePath=/app/src/modules
-        - -w
-        - /app
-        - russellseymour/runner-pwsh:0.0.4
-        - pwsh
-        - -NoProfile
-        - -Command
-    quote: "'"
+import:
+# Contexts
+- https://raw.githubusercontent.com/amido/stacks-pipeline-templates/875d45a6e44aeca0ff51db864a24631a81b2cd2c/taskctl/contexts.yml
 
-  powershell:
-    executable:
-      bin: docker
-      args:
-        - run
-        - --env-file envfile
-        - --rm
-        - -v
-        - ${PWD}:/app
-        - -v
-        - /var/run/docker.sock:/var/run/docker.sock
-        - -e
-        - PSModulePath=/app/src/modules
-        - -w
-        - /app
-        - russellseymour/runner-pwsh:0.0.4
-        - pwsh
-        - -NoProfile
-        - -Command
-    quote: "'"
-    before: env | grep -v PATH > envfile
+# contexts:
+#   docsenv:
+#     executable:
+#       bin: docker
+#       args:
+#         - run
+#         - --rm
+#         - -v
+#         - ${PWD}:/app
+#         - -e
+#         - PSModulePath=/app/src/modules        
+#         - -w
+#         - /app
+#         - russellseymour/pandoc-asciidoctor
+#         - pwsh
+#         - -NoProfile
+#         - -Command
+#     quote: "'"
 
-  dotnet:
-    executable:
-      bin: docker
-      args:
-        - run
-        - --rm
-        - -v
-        - ${PWD}:/app
-        - -v
-        - /var/run/docker.sock:/var/run/docker.sock
-        - -e
-        - PSModulePath=/app/src/modules
-        - -w
-        - /app
-        - russellseymour/runner-pwsh-dotnet:0.0.3
-        - pwsh
-        - -NoProfile
-        - -Command
-    quote: "'"    
+#   powershell_test:
+#     executable:
+#       bin: docker
+#       args:
+#         - run
+#         - --rm
+#         - -v
+#         - ${PWD}:/app
+#         - -v
+#         - /var/run/docker.sock:/var/run/docker.sock
+#         - -e
+#         - PSModulePath=/app/src/modules
+#         - -w
+#         - /app
+#         - russellseymour/runner-pwsh:0.0.4
+#         - pwsh
+#         - -NoProfile
+#         - -Command
+#     quote: "'"
+
+#   powershell:
+#     executable:
+#       bin: docker
+#       args:
+#         - run
+#         - --env-file envfile
+#         - --rm
+#         - -v
+#         - ${PWD}:/app
+#         - -v
+#         - /var/run/docker.sock:/var/run/docker.sock
+#         - -e
+#         - PSModulePath=/app/src/modules
+#         - -w
+#         - /app
+#         - russellseymour/runner-pwsh:0.0.4
+#         - pwsh
+#         - -NoProfile
+#         - -Command
+#     quote: "'"
+#     before: env | grep -v PATH > envfile
+
+#   dotnet:
+#     executable:
+#       bin: docker
+#       args:
+#         - run
+#         - --rm
+#         - -v
+#         - ${PWD}:/app
+#         - -v
+#         - /var/run/docker.sock:/var/run/docker.sock
+#         - -e
+#         - PSModulePath=/app/src/modules
+#         - -w
+#         - /app
+#         - russellseymour/runner-pwsh-dotnet:0.0.3
+#         - pwsh
+#         - -NoProfile
+#         - -Command
+#     quote: "'"    
 
 tasks:
 


### PR DESCRIPTION
Please note: intermediate fix was required for the centralisation of TaskCTL tasks, so the branch name is not accurate.

📲 What

Adds support for generic Docker Registries
Fixes Broken Publish-GitHubRelease tests

🤔 Why

Generic docker registries as required to support the build and publish the images used by the independent runner.

Broken tests for Publish-GitHubRelease

🛠 How

Standard PS function implementation.

👀 Evidence

Locally, the Build-DockerImage command is run and has deployed to a generic registry, https://hub.docker.com/repository/docker/williamamido/runner-pwsh while tests continue to succeed.

Publish-GitHubRelease tests now run 100% : https://amido-dev.visualstudio.com/Amido-Stacks/_TestManagement/Runs?runId=1112474&_a=runCharts

🕵️ How to test
The following command will succeed when running in the `stacks-docker-images` repo, assuming you have set the relevant environmental vars for `DOCKER_USERNAME` and `DOCKER_PASSWORD`:
`Build-DockerImage  -buildargs ./image_definitions/base -name <YOUR-ORG-HERE>/runner-pwsh -tag 0.0.3-untested -push -generic -registry docker.io`