### PR TITLE
BUGFIX : Rewrites registry value for ACR login.

### DIFF
--- a/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
@@ -38,7 +38,7 @@ function Build-DockerImage() {
             ParameterSetName="push"
         )]
         [string]
-        # Docker registry to push the image to
+        # Docker registry FQDN to push the image to
         $registry = $env:DOCKER_CONTAINER_REGISTRY_NAME,
 
         [string]
@@ -126,8 +126,11 @@ function Build-DockerImage() {
             # Login to azure
             Connect-Azure
 
+            # Rewrite Registry value to obtain Azure Resourece Name:
+            $registryName = $registry.split(".")[0]
+
             # Get the credentials for the registry
-            $creds = Get-AzContainerRegistryCredential -Name $registry -ResourceGroup $group
+            $creds = Get-AzContainerRegistryCredential -Name $registryName -ResourceGroup $group
         
             $cmd = "docker login {0} -u {1} -p {2}" -f $registry, $creds.UserName, $creds.Password
 


### PR DESCRIPTION
# BUGFIX : Rewrites registry value for ACR login.

## 📲 What

Splits azurecr.io suffix from ACR-based registry pushes

## 🤔 Why

To ensure support of multiple container registries, the safer bet is to amend the variable used to include the suffix, and have it split conditionally when an ACR is specified.

## 🛠 How

Standard PS.

## 👀 Evidence

Link to [builds](https://dev.azure.com/amido-dev/Amido-Stacks/_build/results?buildId=20667&view=results)

## 🕵️ How to test

Notes for QA