### PR TITLE
Feature/kubectl

### DIFF
--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -32,7 +32,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh-pester:0.3.39-main
+        - amidostacks/runner-pwsh:0.3.54-versionbump
         - pwsh
         - -NoProfile
         - -Command
@@ -53,7 +53,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.39-main
+        - amidostacks/runner-pwsh:0.3.54-versionbump
         - pwsh
         - -NoProfile
         - -Command
@@ -75,7 +75,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.39-main
+        - amidostacks/runner-pwsh:0.3.54-versionbump
         - pwsh
         - -NoProfile
         - -Command
@@ -96,7 +96,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.39-main
+        - amidostacks/runner-pwsh-dotnet:0.3.54-versionbump
         - pwsh
         - -NoProfile
         - -Command

--- a/src/modules/AmidoBuild/exported/Invoke-Kubectl.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Kubectl.ps1
@@ -49,11 +49,9 @@ function Invoke-Kubectl() {
     switch ($provider) {
         "Azure" {
             Invoke-Login -Azure -k8s -k8sName $target -resourceGroup $identifier
-            return $LASTEXITCODE
         }
         "AWS" {
             Invoke-Login  -AWS -k8s -k8sName $target -region $identifier
-            return $LASTEXITCODE
         }
         default {
             Write-Error -Message ("Cloud provider not supported for login: {0}" -f $provider)
@@ -68,7 +66,6 @@ function Invoke-Kubectl() {
     # build up and execute the commands that need to be run
     switch ($PSCmdlet.ParameterSetName) {
         "apply" {
-
             # Check that some arguments have been set
             if ($arguments.Count -eq 0) {
                 Write-Error -Message "No manifest files have been specified"
@@ -89,14 +86,12 @@ function Invoke-Kubectl() {
         }
 
         "custom" {
-
             # Build up the command that is to be run
             $commands = "{0} {1}" -f $kubectl, ($arguments -join " ")
         }
 
 
         "rollout" {
-
             # Build up the full kubectl command
             $commands = "{0} rollout {1}" -f $kubectl, ($arguments -join " ")
             

--- a/src/modules/AmidoBuild/exported/Invoke-Kubectl.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Kubectl.ps1
@@ -30,11 +30,35 @@ function Invoke-Kubectl() {
         [string[]]
         [Alias("properties")]
         # Arguments to pass to the kubectl command
-        $arguments
+        $arguments,
+
+        [string]
+        # Cloud Provider
+        $provider = "Azure",
+
+        [string]
+        # Target K8S cluster
+        $target = "example_cluster",
+
+        [string]
+        # Unique identifier for K8S in a given cloud: region for AWS, resourceGroup for Azure, project for GKE
+        $identifier = "example_identifier"
+
     )
 
-    # Login to cloud
-    Invoke-Login
+    switch ($provider) {
+        "Azure" {
+            Invoke-Login -Azure -k8s -k8sName $target -resourceGroup $identifier
+            return $LASTEXITCODE
+        }
+        "AWS" {
+            Invoke-Login  -AWS -k8s -k8sName $target -region $identifier
+            return $LASTEXITCODE
+        }
+        default {
+            Write-Error -Message ("Cloud provider not supported for login: {0}" -f $provider)
+        }
+    } 
 
     # Find the kubectl command to use
     $kubectl = Find-Command -Name "kubectl"

--- a/src/modules/AmidoBuild/exported/Invoke-Kubectl.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Kubectl.ps1
@@ -33,72 +33,88 @@ function Invoke-Kubectl() {
         $arguments,
 
         [string]
+        [ValidateSet('azure','aws',IgnoreCase)]
         # Cloud Provider
-        $provider = "Azure",
+        $provider,
 
         [string]
-        # Target K8S cluster
-        $target = "example_cluster",
+        # Target K8S cluster resource name in Cloud Provider
+        $target,
 
         [string]
-        # Unique identifier for K8S in a given cloud: region for AWS, resourceGroup for Azure, project for GKE
-        $identifier = "example_identifier"
+        # Unique identifier for K8S in a given Cloud Provider: region for AWS, resourceGroup for Azure, project for GKE
+        $identifier
 
     )
+    $missing = @()
+    # Ensure that all the required parameters have been set
+    foreach ($parameter in @("provider", "target", "identifier")) {
 
-    switch ($provider) {
-        "Azure" {
-            Invoke-Login -Azure -k8s -k8sName $target -resourceGroup $identifier
-        }
-        "AWS" {
-            Invoke-Login  -AWS -k8s -k8sName $target -region $identifier
-        }
-        default {
-            Write-Error -Message ("Cloud provider not supported for login: {0}" -f $provider)
-        }
-    } 
-
-    # Find the kubectl command to use
-    $kubectl = Find-Command -Name "kubectl"
-
-    $commands = @()
-
-    # build up and execute the commands that need to be run
-    switch ($PSCmdlet.ParameterSetName) {
-        "apply" {
-            # Check that some arguments have been set
-            if ($arguments.Count -eq 0) {
-                Write-Error -Message "No manifest files have been specified"
-                exit 1
-            }
-
-            # Iterate around the arguments that have been specified and deploy each one
-            foreach ($manifest in $arguments) {
-
-                # check that the manifest exists
-                if (!(Test-Path -Path $manifest)) {
-                    Write-Warning -Message ("Unable to find manifest file: {0}" -f $manifest)
-                } else {
-                    $commands += "{0} apply -f {1}" -f $kubectl, $manifest
-                    # Invoke-External -Command $command
-                }
-            }
-        }
-
-        "custom" {
-            # Build up the command that is to be run
-            $commands = "{0} {1}" -f $kubectl, ($arguments -join " ")
-        }
-
-
-        "rollout" {
-            # Build up the full kubectl command
-            $commands = "{0} rollout {1}" -f $kubectl, ($arguments -join " ")
-            
+        # check each parameter to see if it has been set
+        if ([string]::IsNullOrEmpty((Get-Variable -Name $parameter).Value)) {
+            $missing += $parameter
         }
     }
 
-    if ($commands.count -gt 0) {
-        Invoke-External -Command $commands
+    # if there are missing parameters throw an error
+    if ($missing.length -gt 0) {
+        Write-Error -Message ("Required parameters are missing: {0}" -f ($missing -join ", "))
+    } else {
+
+        switch ($provider) {
+            "Azure" {
+                Invoke-Login -Azure -k8s -k8sName $target -resourceGroup $identifier
+            }
+            "AWS" {
+                Invoke-Login  -AWS -k8s -k8sName $target -region $identifier
+            }
+            default {
+                Write-Error -Message ("Cloud provider not supported for login: {0}" -f $provider)
+            }
+        } 
+
+        # Find the kubectl command to use
+        $kubectl = Find-Command -Name "kubectl"
+
+        $commands = @()
+
+        # build up and execute the commands that need to be run
+        switch ($PSCmdlet.ParameterSetName) {
+            "apply" {
+                # Check that some arguments have been set
+                if ($arguments.Count -eq 0) {
+                    Write-Error -Message "No manifest files have been specified"
+                    exit 1
+                }
+
+                # Iterate around the arguments that have been specified and deploy each one
+                foreach ($manifest in $arguments) {
+
+                    # check that the manifest exists
+                    if (!(Test-Path -Path $manifest)) {
+                        Write-Warning -Message ("Unable to find manifest file: {0}" -f $manifest)
+                    } else {
+                        $commands += "{0} apply -f {1}" -f $kubectl, $manifest
+                        # Invoke-External -Command $command
+                    }
+                }
+            }
+
+            "custom" {
+                # Build up the command that is to be run
+                $commands = "{0} {1}" -f $kubectl, ($arguments -join " ")
+            }
+
+
+            "rollout" {
+                # Build up the full kubectl command
+                $commands = "{0} rollout {1}" -f $kubectl, ($arguments -join " ")
+                
+            }
+        }
+
+        if ($commands.count -gt 0) {
+            Invoke-External -Command $commands
+        }
     }
 }

--- a/src/modules/AmidoBuild/exported/Invoke-Login.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Login.Tests.ps1
@@ -43,10 +43,32 @@ Describe "Invoke-Login" {
         Remove-Variable -Name Session -Scope Global
     }
 
+
+
     Context "No cloud platform is specified" {
 
         it "will error" {
-            Invoke-Login
+            try { 
+                Invoke-Login
+            }
+            catch {
+                $err = $true
+            }
+            write-host $err
+            $err | Should -Be $true # This syntax is used because [ParameterBindingException] which is returned is not able to be captured by the Pester `Should -Throw` syntax
+        }
+    }
+
+    Context "No cloud platform details are specified" {
+
+        it "will error" {
+            Invoke-Login -Azure
+
+            Should -Invoke -CommandName Write-Error -Times 1
+        }
+
+        it "will error" {
+            Invoke-Login -AWS
 
             Should -Invoke -CommandName Write-Error -Times 1
         }
@@ -63,8 +85,8 @@ Describe "Invoke-Login" {
 
         it "will login to Azure" {
 
-            $secure = ConvertTo-SecureString -AsPlainText -String xxxx
-            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password $secure
+            # $secure = ConvertTo-SecureString -AsPlainText -String xxxx
+            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password xxxx
 
             Should -Invoke -CommandName Connect-Azure -Times 1
             Should -Invoke -CommandName Import-AzAksCredential -Times 0
@@ -73,7 +95,7 @@ Describe "Invoke-Login" {
         it "will log into Azure and get AKS credentials" {
 
             $secure = ConvertTo-SecureString -AsPlainText -String xxxx
-            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password $secure -aks
+            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password $secure -k8s -k8sname xxxx -resourceGroup yyyy
 
             Should -Invoke -CommandName Connect-Azure -Times 1
             Should -Invoke -CommandName Import-AzAksCredential -Times 1           

--- a/src/modules/AmidoBuild/exported/Invoke-Login.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Login.ps1
@@ -119,7 +119,6 @@ function Invoke-Login() {
 
                 # Connect to Azure
                 Connect-Azure -clientId $username -secret $password -subscription $subscriptionId -tenantId $tenantId
-                return $LASTEXITCODE
                 # Set the subscription that should be used
                 # Set-AzContext -Subscription $subscriptionId
 
@@ -139,7 +138,7 @@ function Invoke-Login() {
                         Write-Error -Message ("Required K8S parameters are missing: {0}" -f ($missing -join ", "))
                     } else {
                     
-                    Import-AzAksCredential -ResourceGroupName $resourceGroup -Name $k8sName
+                    Import-AzAksCredential -ResourceGroupName $resourceGroup -Name $k8sName -Force
                     }
                 }
             }

--- a/src/modules/AmidoBuild/exported/Invoke-Login.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Login.ps1
@@ -4,6 +4,21 @@ function Invoke-Login() {
     [CmdletBinding()]
     param (
 
+        [switch]
+        # Specify if Kubernetes credentials should be retrieved
+        $k8s,
+
+        [string]
+        # Name of the cluster to get credentials for
+        $k8sName,
+
+        [Parameter(
+            ParameterSetName="azure"
+        )]
+        [string]
+        # If logging into AKS then set the resource group that the cluster is in
+        $resourceGroup,
+
         [Parameter(
             ParameterSetName="azure"
         )]
@@ -25,29 +40,53 @@ function Invoke-Login() {
         # ID of the subscription to use for resources
         $subscriptionId = $env:ARM_SUBSCRIPTION_ID,
 
+        [Parameter(
+            ParameterSetName="azure"
+        )]
         [Alias("clientId")]
         [string]
         # Username to use to access the specifiec cloud
-        # For Azure this will the client_secret
-        $username = $env:AMIDOBUILD_LOGIN_USERNAME,
+        # For Azure this will the value for azurerm_client_id
+        $username = $env:ARM_CLIENT_ID,
 
+        [Parameter(
+            ParameterSetName="azure"
+        )]
         [Alias("clientSecret")]
-        [SecureString]
-        # Password to be used
-        # For Azure this will be the client_id
-        $password = $env:AMIDOBUILD_LOGIN_PASSWORD,
+        [string]
+        # Password to be used - this is not leveraged as a SecureString, so it can be sourced from an environment variable
+        # For Azure this will be the value for azurerm_client_secret
+        $password = $env:ARM_CLIENT_SECRET,
 
+        [Parameter(
+            ParameterSetName="aws"
+        )]
         [switch]
-        # Specify if AKS credentials should be retrieved
-        $aks,
+        # Cloud being connected to
+        $aws,
 
+        [Parameter(
+            ParameterSetName="aws"
+        )]
         [string]
-        # If logging into AKS then set the group that the cluster is in
-        $k8sGroup,
+        # Cloud being connected to
+        $key_id = $env:AWS_ACCESS_KEY_ID,
 
+        [Parameter(
+            ParameterSetName="aws"
+        )]
         [string]
-        # Name of the cluster to get cerdentials for
-        $k8sName
+        # Password to be used
+        # For Azure this will be the value for azurerm_client_id
+        # For AWS this will be the value for AWS_SECRET_ACCESS_KEY
+        $key_secret = $env:AWS_SECRET_ACCESS_KEY,
+
+        [Parameter(
+            ParameterSetName="aws"
+        )]
+        [string]
+        # If logging into EKS then set the resource group that the cluster is in
+        $region = $env:AWS_DEFAULT_REGION
 
     )
 
@@ -80,15 +119,69 @@ function Invoke-Login() {
 
                 # Connect to Azure
                 Connect-Azure -clientId $username -secret $password -subscription $subscriptionId -tenantId $tenantId
-
+                return $LASTEXITCODE
                 # Set the subscription that should be used
                 # Set-AzContext -Subscription $subscriptionId
 
                 # Import AKS credentials if specified
-                if ($aks.IsPresent) {
-                    Import-AzAksCredential -ResourceGroupName $k8sGroup -Name $k8sName
+                if ($k8s.IsPresent) {
+                    
+                    foreach ($parameter in @("k8sname", "resourceGroup")) {
+
+                        # check each parameter to see if it has been set
+                        if ([string]::IsNullOrEmpty((Get-Variable -Name $parameter).Value)) {
+                            $missing += $parameter
+                        }
+                    }
+        
+                    # if there are missing parameters throw an error
+                    if ($missing.length -gt 0) {
+                        Write-Error -Message ("Required K8S parameters are missing: {0}" -f ($missing -join ", "))
+                    } else {
+                    
+                    Import-AzAksCredential -ResourceGroupName $resourceGroup -Name $k8sName
+                    }
                 }
             }
+        }
+
+        "aws" {
+
+            # Ensure that all the required parameters have been set
+            foreach ($parameter in @("region", "key_id", "key_secret")) {
+
+                # check each parameter to see if it has been set
+                if ([string]::IsNullOrEmpty((Get-Variable -Name $parameter).Value)) {
+                    $missing += $parameter
+                }
+            }
+
+            # if there are missing parameters throw an error
+            if ($missing.length -gt 0) {
+                Write-Error -Message ("Required parameters are missing: {0}" -f ($missing -join ", "))
+            } else {
+                Write-Warning -Message ("AWS not yet implemented, would be checking for AWS env vars for AWS_ACCESS_KEY_ID={0} , and AWS_SECRET_ACCESS_KEY (not shown) and AWS_DEFAULT_REGION={1}" -f $key_id, $region)
+
+                # Import EKS credentials if specified
+                if ($k8s.IsPresent) {
+                    
+                    foreach ($parameter in @("k8sname", "region")) {
+
+                        # check each parameter to see if it has been set
+                        if ([string]::IsNullOrEmpty((Get-Variable -Name $parameter).Value)) {
+                            $missing += $parameter
+                        }
+                    }
+        
+                    # if there are missing parameters throw an error
+                    if ($missing.length -gt 0) {
+                        Write-Error -Message ("Required K8S parameters are missing: {0}" -f ($missing -join ", "))
+                    } else {
+                        Write-Warning -Message ("EKS not yet implemented, would be running something like: aws eks update-kubeconfig --name {0} —region {1}" -f $k8sName, $region)
+                    }
+                }
+            }
+            Write-Error -Message ("Not authenticated")
         }
 
         default {
@@ -102,6 +195,4 @@ function Invoke-Login() {
             return
         }
     }
-
-
 }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Implements Invoke-KubeCTL.

1. Supports `-target <cluster>`, `-identifier <group, region, project>`, and `-provider <cloudname>` to pass through to `invoke-login` as required.
3. Renames `-aks` to `-k8s` in order to proactively support more cloud providers
4.  Adds validation for initial parameters, and again if `-k8s` is specified

Updates Invoke-Login.

1. Supports separate ParameterSets for AWS and Azure
2. Implements basic user feedback for non-functional AWS commands
3. Implements Azure-specific syntax with generic `invoke-kubectl` parameters for obtaining K8S credentials

## 🤔 Why

Initial implementation

## 🛠 How

Standard PS

## 👀 Evidence

[Link to builds](https://dev.azure.com/amido-dev/Amido-Stacks/_build/results?buildId=20991&view=results)

## 🕵️ How to test

As per PS Docs