### PR TITLE
Fix issue when ceating a Docker image

### DIFF
--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -65,13 +65,6 @@ stages:
             script: |
               taskctl docs
 
-        - task: Bash@3
-          inputs: 
-            targetType: inline
-            script: |
-              tree $(Build.SourcesDirectory)/outputs
-              cat $(Build.SourcesDirectory)/outputs/tests/pester-unittest-results.xml
-
         # Upload tests and the coverage results
         - task: PublishTestResults@2
           inputs:

--- a/src/modules/AmidoBuild/command/Invoke-External.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.ps1
@@ -51,6 +51,10 @@ function Invoke-External {
         }
 
         if ($execute) {
+
+            # Output the command being called
+            Write-Information -MessageDate $command
+
             $output = Invoke-Expression -Command $command
 
             Write-Output -InputObject $output

--- a/src/modules/AmidoBuild/exported/Build-DockerImage.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.Tests.ps1
@@ -115,6 +115,15 @@ Describe "Build-DockerImage" {
 
             $Session.commands.list[0] | Should -BeLike "*docker* build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest"
         }
+
+        It "will correctly change the case of the input to create a valid image" {
+            
+            # Call the function under test
+            Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg"
+
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest"
+
+        }
     }
 
     Context "Build image and push" {

--- a/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
@@ -90,6 +90,12 @@ function Build-DockerImage() {
         Write-Error -Message "Pushing to a generic registry requires environment variables DOCKER_USERNAME and DOCKER_PASSWORD to be set"
         return
     }
+
+    # Ensure that the name and the tagare lowercase so that Docker does not 
+    # throw an error with invalid strings
+    $name = $name.ToLower()
+    $tag = $tag.ToLower()
+
     # Create an array to store the arguments to pass to docker
     $arguments = @()
     $arguments += $buildArgs


### PR DESCRIPTION
## 📲 What

Updated the `Build-DockerImage` cmdlet so that the name and tag are changed to lower case when called by Docker.

Output the command being called to the console during the build.

## 🤔 Why

Docker does not allow names of images or the tags to be anything other than lowercase.

It is hard to debug issues in the pipeline when the command that has been executed cannot be checked.

## 🛠 How

For the name and the tag a simple lowercase conversion is being perfomed in the function. The tests have been updated to test for this evntuallity.

A simple `Write-Information` call has been added to the `Invoke-External` command when a command is about to be executed, e.g. not in dry-run. This will output the command to the log.

