### PR TITLE
Fix value of environment variables going into Docker

### DIFF
--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -65,13 +65,6 @@ stages:
             script: |
               taskctl docs
 
-        - task: Bash@3
-          inputs: 
-            targetType: inline
-            script: |
-              tree $(Build.SourcesDirectory)/outputs
-              cat $(Build.SourcesDirectory)/outputs/tests/pester-unittest-results.xml
-
         # Upload tests and the coverage results
         - task: PublishTestResults@2
           inputs:

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -58,7 +58,7 @@ contexts:
         - -NoProfile
         - -Command
     quote: "'"
-    before: env | grep -v PATH | grep -v SOURCEVERSIONMESSAGE > envfile
+    before: env | grep -v PATH | awk -F '=' '{print $1 "=" "\"" $2 "\""}' > envfile
 
   powershell:
     executable:
@@ -80,7 +80,7 @@ contexts:
         - -NoProfile
         - -Command
     quote: "'"
-    before: env | grep -v PATH | grep -v SOURCEVERSIONMESSAGE > envfile
+    before: env | grep -v PATH | awk -F '=' '{print $1 "=" "\"" $2 "\""}' > envfile
 
   dotnet:
     executable:


### PR DESCRIPTION
## 📲 What

Added quotes to the values in the envvar file

## 🤔 Why

In the `envfile` created for the context the values of the variables are not quoted which means that values that have spaces can and will cause Docker to throw an error.

## 🛠 How

Added an `awk` command to the command pipeline so that all values are quoted in the file.

## 👀 Evidence

The values in the file are now properly quoted

![image](https://user-images.githubusercontent.com/791658/165545681-f676ed18-0b07-4c98-a4c6-1080b2f86f93.png)


