### PR TITLE
Corrected parameter name

### DIFF
--- a/src/modules/AmidoBuild/command/Invoke-External.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.ps1
@@ -53,7 +53,7 @@ function Invoke-External {
         if ($execute) {
 
             # Output the command being called
-            Write-Information -MessageDate $command
+            Write-Information -Message $command
 
             $output = Invoke-Expression -Command $command
 

--- a/src/modules/AmidoBuild/command/Invoke-External.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.ps1
@@ -53,7 +53,7 @@ function Invoke-External {
         if ($execute) {
 
             # Output the command being called
-            Write-Information -Message $command
+            Write-Information -MessageData $command
 
             $output = Invoke-Expression -Command $command
 


### PR DESCRIPTION
## 📲 What

Corrected the parameter name for `Write-Information`

## 🤔 Why

The parameter had been misspelled and caused the cmdlet to break

## 🛠 How

Corrected the name

## 👀 Evidence

Tests are now running and passing.

We need to make sure that failed tests fail the build

