### PR TITLE
Permits ECR image push and EKS deployment

### DIFF
--- a/src/modules/AmidoBuild/cloud/Connect-EKS.Tests.ps1
+++ b/src/modules/AmidoBuild/cloud/Connect-EKS.Tests.ps1
@@ -1,0 +1,36 @@
+Describe "Connect-EKS" {
+
+    BeforeAll {
+
+        # Import funciton under test
+        . $PSScriptRoot/Connect-EKS.ps1
+
+        # Import dependencies
+        . $PSScriptRoot/../utils/Confirm-Parameters.ps1
+
+        # Mocks
+        # - Write-Error
+        Mock -CommandName Write-Error -MockWith {}
+
+        # - Invoke-External
+        Mock -CommandName Invoke-External -MockWith { return }
+    }
+
+    Context "Use parameters" {
+
+        It "will raise an error as not all the required params have been set" {
+
+            Connect-EKS
+
+            Should -Invoke -CommandName Write-Error -Times 1
+        }
+
+        It "will connect to Azure" {
+
+          Connect-EKS -name xxxx -region yyyy
+
+            Should -Invoke -CommandName Invoke-External -Times 1
+        }
+    }
+
+}

--- a/src/modules/AmidoBuild/cloud/Connect-EKS.Tests.ps1
+++ b/src/modules/AmidoBuild/cloud/Connect-EKS.Tests.ps1
@@ -7,6 +7,7 @@ Describe "Connect-EKS" {
 
         # Import dependencies
         . $PSScriptRoot/../utils/Confirm-Parameters.ps1
+        . $PSScriptRoot/../command/Invoke-External.ps1
 
         # Mocks
         # - Write-Error

--- a/src/modules/AmidoBuild/cloud/Connect-EKS.ps1
+++ b/src/modules/AmidoBuild/cloud/Connect-EKS.ps1
@@ -1,0 +1,58 @@
+
+function Connect-EKS() {
+
+  <#
+
+  .SYNOPSIS
+  Connect to azure using environment variables for the parameters
+
+  .DESCRIPTION
+  In order to access EKS, one must run external command `aws eks`. In order to
+  match the protocol used for Connect-Azure, this is exported to separate function.
+
+  This function is not exported outside of the module.
+
+  .EXAMPLE
+
+  Connect to Azure using parameters set on the command line
+
+  Connect-EKS -name cluster -region eu-west-2
+
+
+  #>
+
+  [CmdletBinding()]
+  param (
+
+      [Alias("cluster")]
+      [string]
+      # Name of the cluster
+      $name,
+
+      [string]
+      # Region the cluster is deployed into
+      $region = "eu-west-2",
+
+      [switch]
+      # Whether to dry run the command
+      $dryrun = $false
+  )
+
+  # Ensure that all the required parameters have been set
+  foreach ($parameter in @("name", "region")) {
+
+    # check each parameter to see if it has been set
+    if ([string]::IsNullOrEmpty((Get-Variable -Name $parameter).Value)) {
+        $missing += $parameter
+    }
+  }
+
+  # if there are missing parameters throw an error
+  if ($missing.length -gt 0) {
+      Write-Error -Message ("Required parameter/s are missing: {0}" -f ($missing -join ", "))
+  } else {
+
+    $cmd = "aws eks update-kubeconfig --name {0} --region {1}" -f $name, $region
+    Invoke-External $cmd
+  }
+}

--- a/src/modules/AmidoBuild/exported/Invoke-Login.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Login.Tests.ps1
@@ -8,6 +8,7 @@ Describe "Invoke-Login" {
 
         # Import dependencies
         . $PSScriptRoot/../cloud/Connect-Azure.ps1
+        . $PSScriptRoot/../cloud/Connect-EKS.ps1
 
         # Functions
         # Create function signatures that are used so that they can be mocked
@@ -21,24 +22,35 @@ Describe "Invoke-Login" {
                 $name
             )
         }
-    
+
         # Mock commands
         # - Write-Error - mock this internal function to check that errors are being raised
         Mock -Command Write-Error -MockWith { return $MessageData } -Verifiable
 
+        # Write-Debug is used for credential validation by AWS
+        Mock -Command Write-Debug -Mockwith { return $MessageData }
+
         # - Connect-Azure - as we are just testing the functionality of the Invoke-Login function
         #                   connecting to Azure is not required and thus is mocked
         Mock -Command Connect-Azure -MockWith { return }
-
+        # - Connect EKS -
+        Mock -Command Connect-EKS -MockWith { return }
         # - Import-AzAksCredential
         Mock -Command Import-AzAksCredential -MockWith {}
-    
-        # Create session variable
-        New-Variable -Name Session -Scope Global -Value @{
-            dryrun = $false
+
+      }
+
+    BeforeEach {
+      # Create a session object so that the Invoke-External function does not
+      # execute any commands but the command that would be run can be checked
+        $global:Session = @{
+            commands = @{
+                list = @()
+            }
         }
+
     }
-    
+
     AfterAll {
         Remove-Variable -Name Session -Scope Global
     }
@@ -48,7 +60,7 @@ Describe "Invoke-Login" {
     Context "No cloud platform is specified" {
 
         it "will error" {
-            try { 
+            try {
                 Invoke-Login
             }
             catch {
@@ -61,16 +73,14 @@ Describe "Invoke-Login" {
 
     Context "No cloud platform details are specified" {
 
-        it "will error" {
-            Invoke-Login -Azure
-
+        it "will error for azure" {
+            Invoke-Login -azure
             Should -Invoke -CommandName Write-Error -Times 1
         }
 
-        it "will error" {
-            Invoke-Login -AWS
-
-            Should -Invoke -CommandName Write-Error -Times 1
+        it "will error for aws" {
+          Invoke-Login -aws
+          Should -Invoke -CommandName Write-Error -Times 1
         }
     }
 
@@ -78,15 +88,15 @@ Describe "Invoke-Login" {
 
         it "will error without all required parameters" {
 
-            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx
+            Invoke-Login -azure -TenantId xxxx -SubscriptionId xxxx
 
             Should -Invoke -CommandName Write-Error -Times 1
         }
 
         it "will login to Azure" {
 
-            # $secure = ConvertTo-SecureString -AsPlainText -String xxxx
-            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password xxxx
+            $secure = ConvertTo-SecureString -AsPlainText -String xxxx
+            Invoke-Login -azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password $secure
 
             Should -Invoke -CommandName Connect-Azure -Times 1
             Should -Invoke -CommandName Import-AzAksCredential -Times 0
@@ -95,11 +105,102 @@ Describe "Invoke-Login" {
         it "will log into Azure and get AKS credentials" {
 
             $secure = ConvertTo-SecureString -AsPlainText -String xxxx
-            Invoke-Login -Azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password $secure -k8s -k8sname xxxx -resourceGroup yyyy
+            Invoke-Login -azure -TenantId xxxx -SubscriptionId xxxx -username xxxx -password $secure -k8s -k8sname xxxx -resourceGroup yyyy
 
             Should -Invoke -CommandName Connect-Azure -Times 1
-            Should -Invoke -CommandName Import-AzAksCredential -Times 1           
+            Should -Invoke -CommandName Import-AzAksCredential -Times 1
         }
     }
+
+    Context "AWS with arguments" {
+
+      BeforeAll {
+      # Mocking find-command as AWSCLI  may not exist on testing environment
+      Mock -Command Find-Command -MockWith { return "aws" }
+
+      }
+
+      BeforeEach {
+        # Reset the commands list to an empty array
+        $global:Session.commands.list = @()
+      }
+
+      it "will error without all required parameters" {
+
+          Invoke-Login -aws -key_secret "yyyy"
+
+          Should -Invoke -CommandName Write-Error -Times 1
+      }
+
+      it "will validate login" {
+
+          Invoke-Login -aws -key_id "xxxx" -key_secret "yyyy" -region "eu-west-2"
+
+          Should -Invoke -CommandName Write-Debug -Times 1 # AWS Login validation is only outputted to debug stream
+
+      }
+
+      it "will validate login and get EKS credentials" {
+        Invoke-Login -aws -key_id "xxxx" -key_secret "yyyy" -region "eu-west-2" -k8s -k8sname "zzzz"
+
+        Should -Invoke -CommandName Write-Debug -Times 1 # AWS Login validation is only outputted to debug stream
+        Should -Invoke -CommandName Connect-EKS -Times 1
+
+
+      }
+  }
+
+  Context "AWS with env vars" {
+
+    BeforeAll {
+
+    # Backup any creds that may be in a local env
+    $old_aws_access_key_id = $env:AWS_ACCESS_KEY_ID
+    $old_aws_secret_access_key = $env:AWS_SECRET_ACCESS_KEY
+    $old_aws_default_region = $env:AWS_DEFAULT_REGION
+
+
+    $env:AWS_ACCESS_KEY_ID = "xxxx"
+    $env:AWS_SECRET_ACCESS_KEY = "yyyy"
+    $env:AWS_DEFAULT_REGION = "zzzz"
+    # Mocking find-command as AWSCLI  may not exist on testing environment
+    Mock -Command Find-Command -MockWith { return "aws" }
+
+    }
+
+    BeforeEach {
+      # Reset the commands list to an empty array
+      $global:Session.commands.list = @()
+    }
+
+    it "will validate login" {
+
+        Invoke-Login -aws
+        Write-Debug $($Session.commands.list| out-string)
+        Should -Invoke -CommandName Write-Debug -Times 1 # Login validation is only outputted to debug stream
+
+    }
+
+    it "will validate login and get EKS credentials" {
+      Invoke-Login -aws -k8s -k8sname "zzzz"
+      Write-Debug $($Session.commands.list| out-string)
+      Should -Invoke -CommandName Write-Debug -Times 1 # Login validation is only outputted to debug stream
+      Should -Invoke -CommandName Connect-EKS -Times 1
+
+    }
+
+    AfterAll {
+      # Restore any original AWS auth env vars for when this is run locally
+      $env:AWS_ACCESS_KEY_ID = $old_aws_access_key_id
+      $env:AWS_SECRET_ACCESS_KEY = $old_aws_secret_access_key
+      $env:AWS_DEFAULT_REGION = $old_aws_default_region
+
+      # Null transitional vars
+      $old_aws_access_key_id = $null
+      $old_aws_secret_access_key = $null
+      $old_aws_default_region = $null
+    }
+
+  }
 
 }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Extended `Invoke-Login` to support validation of AWS login credentials, and calling `connect-eks`.
Implemented `connect-eks` as separate cmdlet.

## 🤔 Why

AWS is strategic objective of this work.

`connect-eks` is required as a separate cmdlet despite being a one-liner calling `invoke-external`, in order that it can be both mocked during tests and be wrapped by the flag `-dryrun` which is supported by `invoke-login`. 

## 🛠 How

Standard Module usage.

## 👀 Evidence

Invoke-Login for AWS (without Connect-EKS):
```
> $DebugPreference = "Continue"
> invoke-login -aws            
DEBUG: AWS env vars for AWS_ACCESS_KEY_ID=<omitted> , and AWS_SECRET_ACCESS_KEY (not shown) and AWS_DEFAULT_REGION=eu-west-2 found OK
```

Connect-EKS:
```
> $DebugPreference = "Continue"
> . Connect-EKS.ps1
> Connect-EKS -name <omitted> -region eu-west-2       
DEBUG: aws eks update-kubeconfig --name <omitted> --region eu-west-2                                           
Added new context arn:aws:eks:eu-west-2:<omitted>:cluster/<omitted> to /Users/williamayerst/.kube/config
```

Invoke-Login for AWS (with Connect-EKS)
```
> $DebugPreference = "Continue"
> invoke-login -aws -k8s -k8sname <omitted>
DEBUG: AWS env vars for AWS_ACCESS_KEY_ID=<omitted> , and AWS_SECRET_ACCESS_KEY (not shown) and AWS_DEFAULT_REGION=eu-west-2 found OK
DEBUG: aws eks update-kubeconfig --name amido-stacks-dev-h0ax6owA --region eu-west-2
Updated context arn:aws:eks:eu-west-2:<omitted>:cluster/<omitted> to /Users/williamayerst/.kube/config

```

## 🕵️ How to test

Clone module locally, import modules and test as per evidence.