### PR TITLE
Removed start and end quotes from buildArgs when passed to Docker

### DIFF
--- a/src/modules/AmidoBuild/exported/Build-DockerImage.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.Tests.ps1
@@ -135,6 +135,14 @@ Describe "Build-DockerImage" {
             $Session.commands.list[0] | Should -BeLikeExactly "*docker* build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest"
 
         }
+
+        It "will remove quotes surrounding build args when passing to Docker" {
+
+            # Call the function to test
+            Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -BuildArgs "`"--build-arg functionName=PesterFunction .`""
+
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* build --build-arg functionName=PesterFunction . -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest"
+        }
     }
 
     Context "Build image and push to generic registry" {

--- a/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/AmidoBuild/exported/Build-DockerImage.ps1
@@ -159,7 +159,7 @@ function Build-DockerImage() {
 
     # Create an array to store the arguments to pass to docker
     $arguments = @()
-    $arguments += $buildArgs
+    $arguments += $buildArgs.Trim("`"", " ")
     $arguments += "-t {0}:{1}" -f $name, $tag
 
     # if the registry name has been set, add t to the tasks


### PR DESCRIPTION
## 📲 What

Removed quotes around `buildArgs` that are passed to `docker` in the `Build-DockerImage` cmdlet

## 🤔 Why

When values are passed to the module in Azure DevOps they can be surrounded by literal quotes which makes the docker command invalid, e.g.:

`docker build "--build-arg functionName=PesterFunction ." -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest`

There should be no quotes in the command, docker will return an error stating that exactly one argument should be passed.

## 🛠 How

Have added a trim to the `$buildArgs` variable so that if it contains a strinig with surrounding quotes they will be removed. This will not affect quotes within the string.

## 👀 Evidence

Tests have been added to check that the quotes are removed correctly

When running in ADO with a test Docker image the quotes are removed correctly and the `docker build ...` command executes successfully.

![image](https://user-images.githubusercontent.com/791658/168146745-a49d6855-5d94-4fd5-aa83-f498574932ff.png)

## 🕵️ How to test

Notes for QA