### PR TITLE
Update Invoke-Terraform to handle single backend string

### DIFF
--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -41,10 +41,23 @@ Describe "Invoke-Terraform" {
         It "will initialise Terraform with the supplied arguments" {
 
             # run the function to call terraform with some arguments for the backend
-            Invoke-Terraform -init -Backend "key=tfstate"
+            Invoke-Terraform -init -Backend "key=tfstate,access_key=123456"
 
             # check that the generated command is correct
-            $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate'"
+            $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate' -backend-config='access_key=123456'"
+        }
+
+        It "will initialise Terraform using the environment variable for the backend config" {
+
+            # Set the environment variable to use for the backend parameter
+            $env:TF_BACKEND = "key=tfstate,access_key=123456"
+
+            Invoke-Terraform -init -Backend "key=tfstate,access_key=123456"
+
+            # check that the generated command is correct
+            $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate' -backend-config='access_key=123456'"    
+            
+            Remove-Item Env:\TF_BACKEND
         }
     }
 

--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
@@ -74,7 +74,7 @@ function Invoke-Terraform() {
         [string[]]
         [Alias("backend", "properties")]
         # Arguments to pass to the terraform command
-        $arguments
+        $arguments = $env:TF_BACKEND
 
     )
 
@@ -85,9 +85,14 @@ function Invoke-Terraform() {
     if (@("init").Contains($PSCmdlet.ParameterSetName)) {
 
         # Check that some backend properties have been set
+        # If they have not then raise an error
+        # If they have then check to see if one argument has been raised and if it has split on the comma in case
+        #   all the configs have been passed in as one string
         if ($arguments.Count -eq 0) {
             Write-Error -Message "No properties have been specified for the backend" -ErrorAction Stop
             return
+        } elseif ($arguments.Count -eq 1) {
+            $arguments = $arguments -split ","
         }
     }
 


### PR DESCRIPTION
## 📲 What

Allowed all of the options to be passed to the `backend` parameter of `Invoke-Terraform` in the first item of the array. If this is the case then the method will attempt to split the strng using the `,` character so that the options can be split up as required by Terraform.

An array can still be passed to the method.

## 🤔 Why

Any backed configurations that need to be passed to Terraform init as multiple `-backend-config` switches.

This was catered for if the `backend` parameter to `Invoke-Terraform` was passed as an arry but not if it was passed as a comma delimited string which can be the case on the command lline and definitely the case when using enviornment variables.

## 🛠 How

The Backend configuration can now be specified as trhe `TF_BACKEND` environment variable.

If the method sees that the internal `$arguments` variable only consists of one element then it will attempt to split that string using the `,` character and pass it back to the `$arguments` variable.

NOTE: This only happens if only one string has been passed, if the arguments consists of muitple items no additional modifications or checks are carried out.

There is a chance that a value of the key in the string may contain a comma. If this is the case then the `delimiter` parameter can be used to change what is used. Alternatively the options can be passed in as a string array.

## 👀 Evidence

The tests were first updated to check that the more than one parameter was being passed that the command would render the right Terraform command. Additionally they were updated to ensure that the values could be passed as an enviornment variable.

A test for setting the parameter as a string array did not exist so a new one has been added.

A new parameter was added which allows the command to accept a different delimiter to split the string on, the default is `,` but this can be overridden as required.

## 🕵️ How to test

Notes for QA