### PR TITLE
Moved where splitting out arguments is performed

### DIFF
--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -38,7 +38,7 @@ Describe "Invoke-Terraform" {
             Should -Invoke Write-Error
         }
 
-        It "will initialise Terraform with the supplied arguments" {
+        It "will initialise Terraform with the supplied argument" {
 
             # run the function to call terraform with some arguments for the backend
             Invoke-Terraform -init -Backend "key=tfstate,access_key=123456"
@@ -46,6 +46,15 @@ Describe "Invoke-Terraform" {
             # check that the generated command is correct
             $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate' -backend-config='access_key=123456'"
         }
+
+        It "will initialise Terraform with the supplied argument using a ; as the delimiter in the string" {
+
+            # run the function to call terraform with some arguments for the backend
+            Invoke-Terraform -init -Backend "key=tfstate;access_key=123456" -Delimiter ";"
+
+            # check that the generated command is correct
+            $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate' -backend-config='access_key=123456'"
+        }        
 
         It "will initialise Terraform using the environment variable for the backend config" {
 
@@ -58,6 +67,14 @@ Describe "Invoke-Terraform" {
             $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate' -backend-config='access_key=123456'"    
             
             Remove-Item Env:\TF_BACKEND
+        }
+
+        It "will initialise Terraform using an array of backend arguments" {
+
+            Invoke-Terraform -init -Backend @("key=tfstate", "access_key=123456")
+
+            # check that the generated command is correct
+            $Session.commands.list[0] | Should -BeLike "*terraform* init -backend-config='key=tfstate' -backend-config='access_key=123456'"              
         }
     }
 
@@ -106,6 +123,11 @@ Describe "Invoke-Terraform" {
 
         It "will run the plan command with the specified arguments" {
             Invoke-Terraform -plan -Path $testFolder -arguments "-input=false", "-out=tfplan"
+            $Session.commands.list[0] | Should -BeLike "*terraform* plan -input=false -out=tfplan"
+        }
+
+        It "will run the plan command with the specified string" {
+            Invoke-Terraform -plan -Path $testFolder -arguments "-input=false,-out=tfplan"
             $Session.commands.list[0] | Should -BeLike "*terraform* plan -input=false -out=tfplan"
         }
     }

--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
@@ -74,12 +74,21 @@ function Invoke-Terraform() {
         [string[]]
         [Alias("backend", "properties")]
         # Arguments to pass to the terraform command
-        $arguments = $env:TF_BACKEND
+        $arguments = $env:TF_BACKEND,
+
+        [string]
+        # Delimiter to use to split backend config that has been passed as one string
+        $delimiter = ","
 
     )
 
     # set flag to state if the dir was changed
     $changedDir = $false
+
+    # If the arguments is one element in the array split on the delimiter
+    if ($arguments.Count -eq 1) {
+        $arguments = $arguments -split $delimiter
+    }
 
     # Check parameters exist for certain cmds
     if (@("init").Contains($PSCmdlet.ParameterSetName)) {
@@ -91,8 +100,6 @@ function Invoke-Terraform() {
         if ($arguments.Count -eq 0) {
             Write-Error -Message "No properties have been specified for the backend" -ErrorAction Stop
             return
-        } elseif ($arguments.Count -eq 1) {
-            $arguments = $arguments -split ","
         }
     }
 


### PR DESCRIPTION
## 📲 What

Moved where the arguments are split on the delimiter.

Also checking in the missing code that allows the sdelimiter for the split to be modified.

Updated tests to check that the split works for all situations

## 🤔 Why

In a previous PR the arguments were being split but only for the `init` parameter set. Arguments are also used for the `plan` parameter for example. The splitting of the arguments is now done for all the subcommands.

An update to allow the delimiter to be changed had been missed off the previos PR.

## 🛠 How

If an argument string is detected, e.g. there is just one element to the array then it will be split using the delimiter character (which defaults to ",") at the start of the function, before the selection of the command is performed.

This now means that all commands can be beneift from being supplied one item for the arguments

## 👀 Evidence

New tests have been added to check that this all the permutations are now checked.

![image](https://user-images.githubusercontent.com/791658/169480600-0cc9bd08-5ab2-4ecd-b82e-056ade61a86a.png)


## 🕵️ How to test

Notes for QA