### PR TITLE
Added new cmdlets which check the build environment and stop tasks in the event of an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ local
 outputs
 envfile
 .DS_Store
+docs/reference

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -134,6 +134,7 @@ stages:
             targetType: inline
             script: |
               wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
+              chmod +x /usr/local/bin/envfile
 
         # Publish to GitHub and Build Dashboard
         - task: Bash@3

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -29,6 +29,14 @@ stages:
               wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
               tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
 
+        # Install Stacks Envfile to generate the envfile to be used by docker
+        - task: Bash@3
+          displayName: Install Envfile
+          inputs:
+            targetType: inline
+            script: |
+              wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
+
         # Ensure that no outputs already exist
         - task: Bash@3
           displayName: Clean outputs
@@ -137,4 +145,3 @@ stages:
             env: 
               PUBLISH_RELEASE: $true
               DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
-

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -118,23 +118,23 @@ stages:
             artifact: 'modules'
             path: $(Build.SourcesDirectory)/artifacts/modules
 
-        # Install Taskctl for the build to run
-        - task: Bash@3
-          displayName: Install Taskctl
-          inputs:
-            targetType: inline
-            script: |
-              wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
-              tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
+        # # Install Taskctl for the build to run
+        # - task: Bash@3
+        #   displayName: Install Taskctl
+        #   inputs:
+        #     targetType: inline
+        #     script: |
+        #       wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
+        #       tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
 
-        # Install Stacks Envfile to generate the envfile to be used by docker
-        - task: Bash@3
-          displayName: Install Envfile
-          inputs:
-            targetType: inline
-            script: |
-              wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
-              chmod +x /usr/local/bin/envfile
+        # # Install Stacks Envfile to generate the envfile to be used by docker
+        # - task: Bash@3
+        #   displayName: Install Envfile
+        #   inputs:
+        #     targetType: inline
+        #     script: |
+        #       wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
+        #       chmod +x /usr/local/bin/envfile
 
         # Publish to GitHub and Build Dashboard
         - task: Bash@3
@@ -147,3 +147,4 @@ stages:
             env: 
               PUBLISH_RELEASE: $true
               DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
+

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -118,23 +118,23 @@ stages:
             artifact: 'modules'
             path: $(Build.SourcesDirectory)/artifacts/modules
 
-        # # Install Taskctl for the build to run
-        # - task: Bash@3
-        #   displayName: Install Taskctl
-        #   inputs:
-        #     targetType: inline
-        #     script: |
-        #       wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
-        #       tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
+        # Install Taskctl for the build to run
+        - task: Bash@3
+          displayName: Install Taskctl
+          inputs:
+            targetType: inline
+            script: |
+              wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
+              tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
 
-        # # Install Stacks Envfile to generate the envfile to be used by docker
-        # - task: Bash@3
-        #   displayName: Install Envfile
-        #   inputs:
-        #     targetType: inline
-        #     script: |
-        #       wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
-        #       chmod +x /usr/local/bin/envfile
+        # Install Stacks Envfile to generate the envfile to be used by docker
+        - task: Bash@3
+          displayName: Install Envfile
+          inputs:
+            targetType: inline
+            script: |
+              wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
+              chmod +x /usr/local/bin/envfile
 
         # Publish to GitHub and Build Dashboard
         - task: Bash@3

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -118,6 +118,14 @@ stages:
               wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
               tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
 
+        # Install Stacks Envfile to generate the envfile to be used by docker
+        - task: Bash@3
+          displayName: Install Envfile
+          inputs:
+            targetType: inline
+            script: |
+              wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
+
         # Publish to GitHub and Build Dashboard
         - task: Bash@3
           displayName: Publish Release

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -36,6 +36,7 @@ stages:
             targetType: inline
             script: |
               wget https://github.com/amido/stacks-envfile/releases/download/v${{ variables.StacksEnvfileVersion }}/stacks-envfile-linux-amd64-${{ variables.StacksEnvfileVersion }} -O /usr/local/bin/envfile
+              chmod +x /usr/local/bin/envfile
 
         # Ensure that no outputs already exist
         - task: Bash@3

--- a/build/azuredevops-vars.yml
+++ b/build/azuredevops-vars.yml
@@ -3,6 +3,8 @@
 variables:
   - name: TaskctlVersion
     value: 1.4.2
+  - name: StacksEnvfileVersion
+    value: 0.0.16
   - name: moduleName
     value: AmidoBuild
 

--- a/build/scripts/Build-Help.ps1
+++ b/build/scripts/Build-Help.ps1
@@ -1,0 +1,28 @@
+
+[CmdletBinding()]
+param (
+
+    [string]
+    # Path that the help should be written to
+    $output = "${PSScriptRoot}/../../docs/reference"
+)
+
+# Ensure that the output folder exists
+if (!(Test-Path -Path $output)) {
+    New-Item -Type Directory -Path $output
+}
+
+# Import the module so that all the functions ar available
+Import-Module ${PSScriptRoot}/../../src/modules/AmidoBuild -Force
+
+# Iterate around all of the exported functions and get the help for each one
+$exported = (Get-Module AmidoBuild).ExportedCommands
+foreach ($item in $exported.GetEnumerator()) {
+    
+    # Create the path to the file to create
+    $path = [IO.Path]::Combine($output, ("{0}.adoc" -f $item.Value))
+
+    # Get the help for the function and output to the file
+    Get-Help -Name $item.Value | Out-File -Path $path
+
+}

--- a/build/scripts/Invoke-PesterTests.ps1
+++ b/build/scripts/Invoke-PesterTests.ps1
@@ -28,7 +28,7 @@ param (
 
     [string]
     # Verbsoity of the tests
-    $verbosity = "Detailed"
+    $verbosity = "Normal"
 
 )
 

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -96,7 +96,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - runner-pwsh-dotnet
+        - amidostacks/runner-pwsh-dotnet:0.3.137-main
         - pwsh
         - -NoProfile
         - -Command

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -32,7 +32,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.54-versionbump
+        - amidostacks/runner-pwsh:0.3.137-main
         - pwsh
         - -NoProfile
         - -Command
@@ -53,12 +53,12 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.54-versionbump
+        - amidostacks/runner-pwsh:0.3.137-main
         - pwsh
         - -NoProfile
         - -Command
     quote: "'"
-    before: env | grep -v PATH > envfile
+    before: envfile -e home,path
 
   powershell:
     executable:
@@ -75,12 +75,12 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.54-versionbump
+        - amidostacks/runner-pwsh:0.3.137-main
         - pwsh
         - -NoProfile
         - -Command
     quote: "'"
-    before: env | grep -v PATH > envfile
+    before: envfile -e home,path
 
   dotnet:
     executable:
@@ -96,7 +96,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh-dotnet:0.3.54-versionbump
+        - runner-pwsh-dotnet
         - pwsh
         - -NoProfile
         - -Command

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -9,6 +9,7 @@ tasks:
     description: Build Docs
     context: docsenv
     command:
+      - /app/build/scripts/Build-Help.ps1
       - Build-Documentation -BasePath /app -Pdf -Title "Independent Runner" -AttributeFile /app/build/config/pdf-config.ps1
       - Build-Documentation -BasePath /app -MD -MDX
 

--- a/docs/cmdref.adoc
+++ b/docs/cmdref.adoc
@@ -1,0 +1,56 @@
+## Command Reference
+
+This section shows the help that is built into each of the exported commands.
+
+The help can be accessed for each command using `Get-Help <NAME>` when the module has been loaded.
+
+### Build-DockerImagee
+include::reference/Build-DockerImage.adoc[]
+
+### Build-Documentation
+include::reference/Build-Documentation.adoc[]
+
+### Build-PowerShellModule
+include::reference/Build-PowerShellModule.adoc[]
+
+### Confirm-Environment
+include::reference/Confirm-Environment.adoc[]
+
+### Expand-Template
+include::reference/Expand-Template.adoc[]
+
+### Get-Dependencies
+include::reference/Get-Dependencies.adoc[]
+
+### Get-ExternalCommands
+include::reference/Get-ExternalCommands.adoc[]
+
+### Invoke-DotNet
+include::reference/Invoke-DotNet.adoc[]
+
+### Invoke-GitClone
+include::reference/Invoke-GitClone.adoc[]
+
+### Invoke-SonarScanner
+include::reference/Invoke-SonarScanner.adoc[]
+
+### Invoke-Templater
+include::reference/Invoke-Templater.adoc[]
+
+### Invoke-Terraform
+include::reference/Invoke-Terraform.adoc[]
+
+### Invoke-YamlLint
+include::reference/Invoke-YamlLint.adoc[]
+
+### Publish-GitHubRelease
+include::reference/Publish-GitHubRelease.adoc[]
+
+### Set-Config
+include::reference/Set-Config.adoc[]
+
+### Update-BuildNumber
+include::reference/Update-BuildNumber.adoc[]
+
+### Update-InfluxDashboard
+include::reference/Update-InfluxDashboard.adoc[]

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -12,4 +12,6 @@ include::pipelines.adoc[]
 
 include::docker_images.adoc[]
 
+include::cmdref.adoc[]
+
 include::reference.adoc[]

--- a/docs/notes.adoc
+++ b/docs/notes.adoc
@@ -10,6 +10,24 @@ The README for the Taskctl projects suggests that it is possible to define globa
 
 Variables can be set on a task as well as when that task is called in a pipeline. It appears that even variables set on a task are not available so have to be duplicated on the call to the task in the pipeline.
 
-
 === Creation of env file
 
+In order to pass environment variables to the container that is running the task an environment file is required. The way that this is passed in can be seen in the `build/taskctl/contexts.yaml`, it is a extra parameter to the Docker command:
+
+```yaml
+  powershell_localmodule:
+    executable:
+      bin: docker
+      args:
+        - run
+        - --env-file envfile
+  ...
+```
+
+This file is generated before the command is run in Docker by the `before` command in the same file:
+
+```yaml
+    before: envfile -e home,path
+```
+
+This is an Amido built binary that can be download from https://github.com/amido/stacks-envfile. The very small cross platform application that generates a valid envfile for Docker. This has to be installed before the tasks are run.

--- a/docs/usage/usage.adoc
+++ b/docs/usage/usage.adoc
@@ -17,7 +17,7 @@ This is achieved by using the `before` parameter of the pipeline context and the
       quote: "'"
       env:
         arguments: "-v q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover" // <1>
-      before: env | grep -v PATH > envfile
+      before: envfile -e PATH
 
       bin: docker
       args:

--- a/src/modules/AmidoBuild/AmidoBuild.psd1
+++ b/src/modules/AmidoBuild/AmidoBuild.psd1
@@ -86,7 +86,8 @@
         "Set-Config",
         "Update-BuildNumber",
         "Update-InfluxDashboard",
-        "Publish-GitHubRelease"
+        "Publish-GitHubRelease",
+        "Confirm-Environment"
     )
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/modules/AmidoBuild/command/Invoke-External.Tests.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.Tests.ps1
@@ -1,9 +1,12 @@
+
 Describe "Invoke-External" {
 
     BeforeAll {
 
         # Import function under test
         . $PSScriptRoot/Invoke-External.ps1
+
+        . $PSScriptRoot/Stop-Task.ps1
 
         # Create the testFolder
         $testFolder = (New-Item 'TestDrive:\folder' -ItemType Directory).FullName

--- a/src/modules/AmidoBuild/command/Invoke-External.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.ps1
@@ -63,6 +63,13 @@ function Invoke-External {
             if (Get-Variable -Name Session -Scope global -ErrorAction SilentlyContinue) {
                 $global:Session.commands.exitcodes += $LASTEXITCODE
             }
+
+            # Strop the task if the LASTEXITCODE is greater than 0
+            if ($LASTEXITCODE -gt 0) {
+                Stop-Task
+            }
+
+            
         }
     }
 }

--- a/src/modules/AmidoBuild/command/Stop-Task.Tests.ps1
+++ b/src/modules/AmidoBuild/command/Stop-Task.Tests.ps1
@@ -1,0 +1,25 @@
+
+
+Describe "Stop-Task" {
+
+    BeforeAll {
+
+        # Import function under test
+        . $PSScriptRoot/Stop-Task.ps1
+
+        # Include dependent functions
+        . $PSScriptRoot/../utils/Confirm-Parameters.ps1        
+
+        # Mocks
+        # Write-Error - mock to the function that writes out errors
+        Mock -Command Write-Error -MockWith { }
+    }
+
+    It "will write out an error and produce an exception" {
+
+        { Stop-Task -Message "Pester Test" } | Should -Throw "Task failed due to errors detailed above"
+
+        Should -Invoke -CommandName Write-Error -Times 1
+    }
+
+}

--- a/src/modules/AmidoBuild/command/Stop-Task.ps1
+++ b/src/modules/AmidoBuild/command/Stop-Task.ps1
@@ -1,0 +1,51 @@
+
+function Stop-Task() {
+
+    <#
+    
+    .SYNOPSIS
+    Stops a task being run in a Taskctl pipeline
+
+    .DESCRIPTION
+    When commands or other process fail in the pipeline, the entire pipeline must be stopped, it is not enough
+    to call `exit` with an exit code as this does not stop the pipeline. It also causes issues when the module
+    is run on a local development workstation as any failure will cause the console to be terminted.
+    
+    This function is intended to be used in place of `exit` and will throw a PowerShell exception after the
+    error has been written out. This is will stop the pipeline from running and does not close the current
+    console
+
+    The function will also attempt to detect the pipeline that it is being run on and output the correct message
+    string for that CI/CD platform.
+    #>
+
+    [CmdletBinding()]
+    param (
+
+        [Alias("Message")]
+        [string]
+        # Error message to be displayed
+        $error_message
+    )
+
+    if (![string]::IsNullOrEmpty($error_message)) {
+        # Attempt to detect the CI/CD the pipeline is running in and write out messages
+        # in the correct format to be picked up the pipeline
+        # For example if running in Azure DevOps then write a message according to the format
+        #   "##[error]<MESSAGE>"
+        # https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash
+
+        #### Azure DevOps Detection
+        $azdo = Get-ChildItem -Path env:\TF_BUILD -ErrorAction SilentlyContinue
+        if (![String]::IsNullOrEmpty($azdo)) {
+            $error_message = "##[error]{0}" -f $error_message
+        }
+
+        # Write an error
+        # The throw method does not allow formatted text, so use Write-Error here to disp[lay a nicely formatted error
+        Write-Error -Message $error_message
+    }
+
+    # Throw an exception to stop the process
+    throw "Task failed due to errors detailed above"
+}

--- a/src/modules/AmidoBuild/exported/Confirm-Environment.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Confirm-Environment.Tests.ps1
@@ -1,0 +1,66 @@
+
+Describe "Confirm-Environment" {
+
+    BeforeAll {
+
+        # Import function under test
+        . $PSScriptRoot/Confirm-Environment.ps1
+
+        # Import dependent functions
+        . $PSScriptRoot/../command/Stop-Task.ps1
+        . $PSScriptRoot/../utils/Confirm-Parameters.ps1    
+
+        # Create the testFolder
+        $testFolder = (New-Item 'TestDrive:\folder' -ItemType Directory).FullName
+
+        # Create file to be used for testing
+        $stageVarFile = [IO.Path]::Combine($testFolder, "stagevars.yml")
+        Set-Content -Path $stageVarFile -Value @"
+default:
+    variables:
+    credentials:
+        azure:
+            - name: ARM_CLIENT_ID
+
+stages:
+    - name: pester
+      variables:
+        - name: PESTER_TEST_VAR
+"@
+
+        # Mocks
+        # Write-Error - mock to the function that writes out errors
+        Mock -Command Write-Error -MockWith {}
+        Mock -Command Write-Warning -MockWith {}
+
+    }
+
+    Context "Check parameters" {
+
+        It "will error if no path is provided" {
+
+            Confirm-Environment
+
+            Should -Invoke -CommandName Write-Error -Times 1
+        }
+    }
+
+    Context "Enviroment" {
+
+        It "will error and terminate because PESTER_TEST_VAR is not set" {
+
+            { Confirm-Environment -Path $stageVarFile -Stage "pester" } | Should -Throw "Task failed due to errors detailed above"
+
+        }
+
+        # Check that the function will warn if no stage has been specfied
+        # As there are no default variables in the above config file there will be
+        # no error or exception
+        It "will warn if no stage has been specified" {
+
+            Confirm-Environment -Path $stageVarFile
+
+            Should -Invoke -CommandName Write-Warning -Times 1 
+        }
+    }
+}

--- a/src/modules/AmidoBuild/exported/Confirm-Environment.ps1
+++ b/src/modules/AmidoBuild/exported/Confirm-Environment.ps1
@@ -1,0 +1,161 @@
+
+
+function Confirm-Environment() {
+
+    <#
+    
+    .SYNOPSIS
+    Checks that all the environment variables have been configured
+
+    .DESCRIPTION
+    Most of the configuration for Stacks pipelines is done using environment variables
+    and there can be quite a lot of them. This function uses a file in the repository to determine
+    which environment variables are required for different stages and cloud platforms. If any
+    environment variables are missing it will exit the task and stop the pipeline. This is
+    so that things fail as early as possible.
+
+    The structure of the file describing the envrionment is show below.
+
+    default:
+        variables: [{}]
+        credentials:
+            azure:  [{}]
+            aws: [{}]
+    
+    stages:
+        name: <NAME>
+        variables: [{}]
+
+    Each of the `[{}]` denotes an array of the following object
+
+        name: ""
+        description: ""
+
+    When thisd function runs it merges the default variables, the cloud cerdential variables
+    and the stage variables and checks to see that they have been set. If they have not it will
+    output a message stating whicch ones have not been set and then fail the task.
+
+    .PARAMETER path
+    Path to the file containing the stage environment variables
+
+    .PARAMETER cloud
+    Name of the cloud platform being deployed to. Can be set using thew
+    `CLOUD_PLATFORM` environment variable. Currently only supports azure and aws.
+
+    .PARAMETER stage
+    Name of the stage to check the envirnment for. Can be set using the `STAGE` environnment
+    variable.
+
+    This variable is not checked for by this function as it is required by this function. If not
+    specified a warning will be displayed stating that no stage has been specified amd will operate
+    with the default variables.
+    
+    #>
+
+    [CmdletBinding()]
+    param (
+
+        [string]
+        # Path to the file containing the list of environment variables
+        # that must be set in the environment
+        $path,
+
+        [string]
+        # Name of the cloud platform being deployed to. This is so that the credntial
+        # environment variables are checked for correctly
+        $cloud = $env:CLOUD_PLATFORM,
+
+        [string]
+        # Stage being run which determines the variables to be chcked for
+        # This stage will be merged with the default check
+        # If not specified then only the deafult stage will be checked
+        $stage = $env:STAGE
+    )
+
+    # Ensure that the $stage and the $cloud are specified
+    # This needs to be done when the script gets put into the module
+
+    # Check that the specified path exists
+    if (!(Test-Path -Path $path)) {
+        Write-Error -Message ("Specified file does not exist: {0}" -f $path)
+        return
+    }
+
+    # Check that the command ConvertFrom-Yaml exists
+    $exists = Get-Command -Name ConvertFrom-Yaml
+    if ([string]::IsNullOrEmpty($exists)) {
+        Stop-Task -Message "Please ensure that the Powershell-Yaml module is installed"
+    }
+
+    # Create an array to hold the missing environment variables
+    $missing = @()
+
+    # Read in the specified file
+    $stage_variables = Get-Content -Path $path -Raw
+    $stageVars = ConvertFrom-Yaml -Yaml $stage_variables
+
+    # Attempt to get the default variables to check for
+    $required = @{}
+    if ($stageVars.ContainsKey("default")) {
+
+        # get the default variables
+        if($stageVars["default"].ContainsKey("variables")) {
+            $required = $stageVars["default"]["variables"] | ForEach-Object { $_.Name }
+        }
+
+        # get the credentials for the cloud if they have been specified
+        if ($stageVars["default"].ContainsKey("credentials") -and
+            $stageVars["default"]["credentials"].ContainsKey($cloud)) {
+            $required += $stageVars["default"]["credentials"][$cloud] | Where-Object { $_.Required -ne $false } | ForEach-Object { $_.Name }
+        }
+    }
+
+    # If the stage is not null check that it exists int he stages list and if
+    # it does merge with the required list
+    if (![String]::IsNullOrEmpty($stage)) {
+
+        # Attempt to get the stage from the file
+        $_stage = $stageVars["stages"] | Where-Object { $_.Name -eq $stage }
+
+        if ([String]::IsNullOrEmpty($_stage)) {
+            Write-Warning -Message ("Specified stage is unknown: {0}" -f $stage)
+        } else {
+            $required += $_stage["variables"] | Where-Object { $_.Required -ne $false } | ForEach-Object { $_.Name }
+        }
+
+    } else {
+        Write-Warning -Message "No stage has been specified, using default environment variables"
+    }
+
+    # Iterate around all the required variables and ensure that they exist in enviornment
+    # If any of them do not then add to the missing array
+    foreach ($envname in $required) {
+
+        try {
+
+            # In some cases all of the environment variables have been capitalised, this is to do with TaskCtl.
+            # Check for the existence of the variable in UPPER case as well, if it exists create the var with
+            # the correct name and then remove the UPPER case value
+            $path = [IO.Path]::Combine("env:", $envname)
+            $pathUpper = [IO.Path]::Combine("env:", $envname.ToUpper())
+
+            if ((Test-Path -Path $pathUpper) -and !(Test-Path -Path $path)) {
+                New-Item -Path $path -Value (Get-ChildItem -Path $pathUpper).Value
+                Remove-Item -Path $pathUpper -Confirm:$false
+            }
+
+            $dummy = Get-ChildItem -path $path -ErrorAction Stop
+        } catch {
+            # The variable does not exist
+            $missing += $envname
+        }
+    }
+
+    # If there are missing values provide an error messahe and stop the task
+    if ($missing.count -gt 0) {
+
+        # As there is an error the task in Taskctl needs to be stopped
+        Stop-Task -Message ("The following environment variables are missing and must be provided: {0}" -f ($missing -join "`n"))
+
+    }
+}

--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -137,7 +137,7 @@ Describe "Invoke-Terraform" {
             $Session.commands.list[0] | Should -BeLike "*terraform* plan -input=false -out=tfplan"
         }
 
-        It "will will run the the plan command using an environment variable for the arguments" {
+        It "will run the the plan command using an environment variable for the arguments" {
 
             # Set the environment variable to use for the backend parameter
             $env:TF_BACKEND = "-input=false,-out=tfplan"


### PR DESCRIPTION
## 📲 What

Fixed issue with the tests coverage being completed successfully.

Added `Confirm-Environment` that checks all the required environment variables have been set, according to a settings file in the repository.
Added `Stop-Task` which throws an exception which makes `taskctl` break out of the pipeline

Updated documentaion

## 🤔 Why

The task for running the Unit test coverage was failing due to the output of Pester including characters that look like Golang templating

A lot of the configuration in the independent runner can be set using enviornment variables, however it is not obvious what these need to be. The new `Confirm-Environment` cmdlet performs this task and fails when env vars are missing and states which ones need to be set.

When tasks were failing previously, `taskctl` did not break out of the pipeline. This mean that sometimes the pipeline appeared to have succeeded but it had failed.

Most of the cmdlets in the module have help that can be accessed in PowerShell using `Get-Help <Name>` but as we generating documentation this should be included as well.

## 🛠 How

Changed the verbosity of the Invoke-Pester from Detailed to Normal so that `taskctl` does not see the offending string.

When the `Confirm-Parameters` cmdlet finds that an specific environment variable does not exist, it calls the `Stop-Task` cmdlet which throws an exception which causes the pipeline to fail.

The tasks now call a new script`Build-Help.ps1` which iterates around the exported functions and gets the help for each one. This is then saved to a file and the main documentation is then tun.

## 👀 Evidence

The following image shows the `Confirm-Environment` command running and stating the envs that are missing and then calling the `Stop-Task` command to stop the pipeline.

![image](https://user-images.githubusercontent.com/791658/173846807-d9b155d5-1032-4ce6-9226-7ffc5dc20c0d.png)

The following image shows the command help added to the documentation

![image](https://user-images.githubusercontent.com/791658/173847879-8a64ee34-b639-43bf-babd-b3f57f995353.png)


## 🕵️ How to test

Notes for QA