### PR TITLE
Enabled `Confirm-Environment` check for GitHub release

### DIFF
--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -144,6 +144,7 @@ stages:
             script: |
               taskctl release
           env: 
+            STAGE: release
             PUBLISH_RELEASE: $true
             DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
 

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -143,8 +143,7 @@ stages:
             targetType: inline
             script: |
               taskctl release
-          # ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # On main branch runs
-            env: 
-              PUBLISH_RELEASE: $true
-              DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
+          env: 
+            PUBLISH_RELEASE: $true
+            DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
 

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -143,9 +143,10 @@ stages:
             targetType: inline
             script: |
               taskctl release
-          env: 
-            STAGE: release
-            PUBLISH_RELEASE: "true"
-            DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
-            VERSION_NUMBER: $(BUILD_BUILDNUMBER)
+          ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # On main branch runs
+            env: 
+              STAGE: release
+              PUBLISH_RELEASE: "true"
+              DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
+              VERSION_NUMBER: $(BUILD_BUILDNUMBER)
 

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -147,4 +147,5 @@ stages:
             STAGE: release
             PUBLISH_RELEASE: $true
             DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
+            VERSION_NUMBER: $(BUILD_BUILDNUMBER)
 

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -143,7 +143,7 @@ stages:
             targetType: inline
             script: |
               taskctl release
-          ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # On main branch runs
+          # ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # On main branch runs
             env: 
               PUBLISH_RELEASE: $true
               DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -145,7 +145,7 @@ stages:
               taskctl release
           env: 
             STAGE: release
-            PUBLISH_RELEASE: $true
+            PUBLISH_RELEASE: "true"
             DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
             VERSION_NUMBER: $(BUILD_BUILDNUMBER)
 

--- a/build/config/stage_envvars.yml
+++ b/build/config/stage_envvars.yml
@@ -1,6 +1,5 @@
 default:
   variables:
-    - name: STAGE
 
 stages:
 

--- a/build/config/stage_envvars.yml
+++ b/build/config/stage_envvars.yml
@@ -10,6 +10,6 @@ stages:
       - name: API_KEY
       - name: PUBLISH_RELEASE
       - name: COMMIT_ID
-      - name: VERSION
+      - name: VERSION_NUMBER
       - name: ARTIFACTS_DIR
       - name: REPOSITORY

--- a/build/config/stage_envvars.yml
+++ b/build/config/stage_envvars.yml
@@ -1,0 +1,15 @@
+default:
+  variables:
+    - name: STAGE
+
+stages:
+
+  - name: release
+    variables:
+      - name: OWNER
+      - name: API_KEY
+      - name: PUBLISH_RELEASE
+      - name: COMMIT_ID
+      - name: VERSION
+      - name: ARTIFACTS_DIR
+      - name: REPOSITORY

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -72,7 +72,7 @@ contexts:
         - -v
         - /var/run/docker.sock:/var/run/docker.sock
         - -e
-        - PSModulePath=/modules
+        - PSModulePath=/app/src/modules
         - -w
         - /app
         - amidostacks/runner-pwsh:0.3.137-main
@@ -93,7 +93,7 @@ contexts:
         - -v
         - /var/run/docker.sock:/var/run/docker.sock
         - -e
-        - PSModulePath=/modules
+        - PSModulePath=/app/src/modules
         - -w
         - /app
         - amidostacks/runner-pwsh-dotnet:0.3.137-main

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -40,6 +40,12 @@ tasks:
     # env: 
     #  PUBLISH_RELEASE: $true
 
+  setup:environment:
+    context: powershell
+    description: Ensure that the environment is configured correctly
+    command:
+      - Confirm-Environment -Path /app/build/config/stage_envvars.yml
+
   publish:github:
     context: powershell
     description: Publish Release to GitHub

--- a/src/modules/AmidoBuild/exported/Confirm-Environment.ps1
+++ b/src/modules/AmidoBuild/exported/Confirm-Environment.ps1
@@ -77,7 +77,7 @@ function Confirm-Environment() {
 
     # Check that the specified path exists
     if (!(Test-Path -Path $path)) {
-        Write-Error -Message ("Specified file does not exist: {0}" -f $path)
+        Stop-Task -Message ("Specified file does not exist: {0}" -f $path)
         return
     }
 
@@ -95,12 +95,12 @@ function Confirm-Environment() {
     $stageVars = ConvertFrom-Yaml -Yaml $stage_variables
 
     # Attempt to get the default variables to check for
-    $required = @{}
+    $required = @()
     if ($stageVars.ContainsKey("default")) {
 
         # get the default variables
         if($stageVars["default"].ContainsKey("variables")) {
-            $required = $stageVars["default"]["variables"] | ForEach-Object { $_.Name }
+            $required += $stageVars["default"]["variables"] | ForEach-Object { $_.Name }
         }
 
         # get the credentials for the cloud if they have been specified

--- a/src/modules/AmidoBuild/exported/Confirm-Environment.ps1
+++ b/src/modules/AmidoBuild/exported/Confirm-Environment.ps1
@@ -127,6 +127,9 @@ function Confirm-Environment() {
         Write-Warning -Message "No stage has been specified, using default environment variables"
     }
 
+    # ensure that required does not contain "empty" items
+    $required = $required | Where-Object { $_ -match '\S' }
+
     # Iterate around all the required variables and ensure that they exist in enviornment
     # If any of them do not then add to the missing array
     foreach ($envname in $required) {

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -17,8 +17,13 @@ pipelines:
     - task: generate
   
   release:
+    - task: setup:environment
     - task: update:dashboard
+      depends_on:
+        - setup:environment
     - task: publish:github
+      depends_on:
+        - setup:environment
     
   all:
     - task: clean


### PR DESCRIPTION
## 📲 What

Added a new task in the pipeline called `setup:environment` which calls the `Confirm-Environment` PowerShell function to ensure all the enviornment variables exist for the successful running of the pipeline

## 🤔 Why

After the last PR the release stage ran but there was no release on GitHub.

By adding the `Confirm-Environment` is it possible now to check that all the required enviornment variables exist to allow the task to complete.

## 🛠 How

Modified the `context.yaml` file so that the module itself is picked up, this means that the latest version is being used when performing the build.

Added  a new file `stage_envvars.yml` to the repo to ensure that the `Confirm-Enviornment` function has the necessary config to determine which vars should exist.

## 👀 Evidence

When the guard for running a release on a branch was removed a release was created on GitHub. This release has been removed.

## 🕵️ How to test

Notes for QA