### PR TITLE
Updated AsciiDoc substitutions to include all environment vars

### DIFF
--- a/src/modules/AmidoBuild/exported/Invoke-Asciidoc.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Asciidoc.Tests.ps1
@@ -30,6 +30,8 @@ Describe "Invoke-Asciidoc" {
         $settings_file = [IO.Path]::Combine($testfolder, "settings.json")
         Set-Content -Path $settings_file -Value ($settings | ConvertTo-Json) | Out-Null
 
+        $env:BUILDNUMBER = "74.83.10.13"
+
         # Mock functions that are called
         # - Find-Command - return the name of the command that is required
         Mock -Command Find-Command -MockWith { return $name }
@@ -66,12 +68,13 @@ Describe "Invoke-Asciidoc" {
             # Create attributes array
             $attributes = @(
                 "allow-read-uri",
-                "pdf-fontsdir=/fonts"
+                "pdf-fontsdir=/fonts",
+                "stackscli_version={{ BUILDNUMBER }}"
             )
 
             Invoke-Asciidoc -pdf -path $testfolder -output "${testfolder}/newsletter.pdf" -attributes $attributes
 
-            $Session.commands.list[0] | Should -BeLike "*asciidoctor-pdf* -a allow-read-uri -a pdf-fontsdir=/fonts -o `"newsletter.pdf`" -D `"$testfolder`" $testfolder"
+            $Session.commands.list[0] | Should -BeLike "*asciidoctor-pdf* -a allow-read-uri -a pdf-fontsdir=/fonts -a stackscli_version=74.83.10.13 -o `"newsletter.pdf`" -D `"$testfolder`" $testfolder"
 
             Should -Invoke -CommandName Write-Information -Times 1
         }


### PR DESCRIPTION
## 📲 What

Allow environment variables to be used in AsciiDoc attribute substituions

## 🤔 Why

A lot of the documentation that is generated in Stacks has references to the version number that has been built. However the value for BUILDNUMBER has not be substituted in and the default of `100.98.99` is being used.

By adding all environment variables to the tokens hashtable in the `Invoke-AsciiDoc` cmdlet it is possible to allow any substitution as an attribuite.

## 🛠 How

The `Invoke-AsciiDoc` cmdlet has a tokens hashtable that already contained the format and basepath.

This has now been augmented so that all environment variables are added to the table.

## 👀 Evidence

Unittests have been updated to include a substitution at the attribute level.

## 🕵️ How to test

Notes for QA