### PR TITLE
Updates Workspace Command

### DIFF
--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
@@ -301,23 +301,11 @@ function Invoke-Terraform() {
             if ([String]::IsNullOrEmpty($arguments)) {
                 Write-Warning -Message "No workspace name specified to create or switch to."
             } else {
-                Write-Information -MessageData ("Attempting to select workspace: {0}" -f $arguments[0])
-                $command = "{0} workspace select {1}" -f $terraform, $arguments[0]
-
-                try {
+                Write-Information -MessageData ("Attempting to select or create workspace: {0}" -f $arguments[0])
+                $command = "{0} workspace select -or-create=true {1} " -f $terraform, $arguments[0]
                     Invoke-External -Command $command
                 }
-                catch [StopTaskException] {
-                    # if the lastexitcode is 1 then create the workspace
-                    if ($_.Exception.ExitCode -eq 1) {
-                        Write-Information -MessageData "Creating workspace as it does not exist"
-                        $command = "{0} workspace new {1}" -f $terraform, $arguments[0]
-                        Invoke-External -Command $command
-                    }
-                }
             }
-        }
-
 
     }
 


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Adds `-or-create` flag to workspace selection command

## 🤔 Why

Do not need to error check for failed workspace selection commands

## 🛠 How

Update PS

## 👀 Evidence

```
PS /Users/williamayerst/Repos/Stacks/independent-runner> invoke-terraform -Workspace -Arguments bacon                 
Tool found: /opt/homebrew/bin/terraform
Working directory: /Users/williamayerst/Repos/Stacks/independent-runner
Attempting to select or create workspace: bacon
terraform workspace select -or-create=true bacon
Created and switched to workspace "bacon"!

You're now on a new, empty workspace. Workspaces isolate their state,
so if you run "terraform plan" Terraform will not see any existing state
for this configuration.
PS /Users/williamayerst/Repos/Stacks/independent-runner> 
```

## 🕵️ How to test

Notes for QA