### PR TITLE
fix(docs): correct typo in Confirm-Environment

### DIFF
--- a/src/modules/EnsonoBuild/exported/Confirm-Environment.ps1
+++ b/src/modules/EnsonoBuild/exported/Confirm-Environment.ps1
@@ -33,7 +33,7 @@ function Confirm-Environment() {
         required: boolean
         cloud: <CLOUD>
 
-    When thisd function runs it merges the default variables, the cloud cerdential variables
+    When this function runs it merges the default variables, the cloud cerdential variables
     and the stage variables and checks to see that they have been set. If they have not it will
     output a message stating whicch ones have not been set and then fail the task.
 


### PR DESCRIPTION
## 📲 What

Corrected a typographical error in documentation.
