### PR TITLE
Add Deploy-HelmCharts function and associated tests for Helm chart deployment

### DIFF
--- a/src/modules/EnsonoBuild/EnsonoBuild.psd1
+++ b/src/modules/EnsonoBuild/EnsonoBuild.psd1
@@ -101,7 +101,8 @@
         "Set-Config",
         "Stop-Task",
         "Update-BuildNumber",
-        "Update-InfluxDashboard"
+        "Update-InfluxDashboard",
+        "Deploy-HelmCharts"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.Tests.ps1
@@ -361,6 +361,34 @@ charts:
             Should -Invoke -CommandName Invoke-WebRequest -Times 1
             Should -Invoke -CommandName Add-Content -ParameterFilter { $Path -like "*Chart.yaml" } -Times 1
         }
+
+        It "will use default version 0.0.1 when no versioning_regex is provided" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-raw-yaml.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Add-Content -ParameterFilter { $Value -like "*version: 0.0.1*" } -Times 1
+        }
+
+        It "will extract version from URL when versioning_regex is provided" {
+            $testConfigVersioned = @"
+charts:
+  - name: versioned-manifest
+    enabled: true
+    location: https://example.com/manifests/v1.2.3/manifest.yaml
+    wrap_raw_yaml: true
+    versioning_regex: '/v(\d+\.\d+\.\d+)/'
+    namespace: default
+"@
+            Set-Content -Path "test-versioned-yaml.yaml" -Value $testConfigVersioned
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-versioned-yaml.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Add-Content -ParameterFilter { $Value -like "*version: 1.2.3*" } -Times 1
+
+            Remove-Item -Path "test-versioned-yaml.yaml" -Force -ErrorAction SilentlyContinue
+        }
     }
 
     Context "Rollout status checks" {

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.Tests.ps1
@@ -1,0 +1,415 @@
+Describe "Deploy-HelmCharts" {
+
+    $ModulePath
+
+    BeforeAll {
+
+        $InformationPreference = 'Continue'
+
+        # Null any env vars which can be used to alter behaviour of the command
+        $env:HELM_CHARTS = $null
+        $env:CLOUD_PROVIDER = $null
+        $env:CLOUD_PLATFORM = $null
+
+        # Make stubbed module available
+        $ModulePath = $env:PSModulePath
+        $env:PSModulePath = "$PSScriptRoot/../../../../test/stubs/modules$([IO.Path]::PathSeparator)$env:PSModulePath"
+
+        # Import the function being tested
+        . $PSScriptRoot/Deploy-HelmCharts.ps1
+
+        # Import dependencies that the function under test requires
+        . $PSScriptRoot/../exported/Invoke-Helm.ps1
+        . $PSScriptRoot/../exported/Expand-Template.ps1
+
+        # Mock functions that are called
+        Mock -Command Invoke-Helm -MockWith { return }
+        Mock -Command Expand-Template -MockWith {
+            param($Template, $Target)
+            # Ensure the directory exists
+            $targetDir = Split-Path -Path $Target -Parent
+            if (-not (Test-Path -Path $targetDir)) {
+                New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+            }
+            # Write the template to the target
+            Set-Content -Path $Target -Value $Template -Force
+        }
+        Mock -Command Invoke-Expression -MockWith { return }
+        Mock -Command Invoke-WebRequest -MockWith { return }
+        Mock -Command Get-Content -MockWith {
+            param($Path, $Raw)
+            # If the path doesn't exist, return empty string to avoid errors
+            if (-not (Test-Path -Path $Path)) {
+                return ""
+            }
+            # Otherwise call the real Get-Content
+            & (Get-Command Get-Content -CommandType Cmdlet) -Path $Path -Raw:$Raw
+        } -ParameterFilter { $Path -like "*values.yaml" -or $Path -like "*Chart.yaml" }
+    }
+
+    AfterAll {
+        $env:PSModulePath = $ModulePath
+    }
+
+    BeforeEach {
+        # Create a session object so that the Invoke-Helm function does not
+        # execute any commands but the command that would be run can be checked
+        $global:Session = @{
+            commands = @{
+                list = @()
+            }
+            dryrun = $true
+        }
+
+        # Set default cloud provider
+        $env:CLOUD_PROVIDER = "azure"
+        $env:CLOUD_PLATFORM = "azure"
+    }
+
+    AfterEach {
+        # Clean up temporary test files
+        if (Test-Path -Path "tmp/") {
+            Remove-Item -Path "tmp/" -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Check mandatory parameters and file validation" {
+
+        BeforeAll {
+            Mock -CommandName Write-Error -MockWith {} -Verifiable
+            Mock -CommandName Write-Warning -MockWith {} -Verifiable
+        }
+
+        It "will use default path if no path is provided" {
+            # Create a dummy config file at the default location
+            $defaultPath = "deploy/helm/k8s_apps.yaml"
+            New-Item -Path (Split-Path $defaultPath -Parent) -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
+            Set-Content -Path $defaultPath -Value "charts: []"
+
+            Deploy-HelmCharts -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false
+
+            Should -Invoke -CommandName Write-Error -Times 0
+
+            # Cleanup
+            Remove-Item -Path "deploy/" -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        It "must error if specified file cannot be located" {
+            Deploy-HelmCharts -Path "non-existent-file.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster"
+
+            Should -Invoke -CommandName Write-Error -Times 1
+        }
+
+        It "will create temporary directory if it does not exist" {
+            # Create a minimal config file
+            $testConfigPath = "test-config.yaml"
+            Set-Content -Path $testConfigPath -Value "charts: []"
+
+            Deploy-HelmCharts -Path $testConfigPath -Tempdir "tmp/" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false
+
+            Test-Path -Path "tmp/" | Should -Be $true
+
+            # Cleanup
+            Remove-Item -Path $testConfigPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Chart filtering and validation" {
+
+        BeforeAll {
+            # Create a test configuration file with multiple charts
+            $testConfig = @"
+charts:
+  - name: nginx-ingress
+    enabled: true
+    location: stable
+    repo: https://kubernetes-charts.storage.googleapis.com
+    namespace: ingress
+  - name: cert-manager
+    enabled: false
+    location: jetstack
+    repo: https://charts.jetstack.io
+  - name: azure-only-chart
+    enabled: true
+    location: azure
+    clouds:
+      - azure
+  - name: aws-only-chart
+    enabled: true
+    location: aws
+    clouds:
+      - aws
+"@
+            Set-Content -Path "test-helm-config.yaml" -Value $testConfig
+        }
+
+        AfterAll {
+            Remove-Item -Path "test-helm-config.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will skip disabled charts" {
+            Mock -CommandName Write-Warning -MockWith {} -Verifiable
+
+            Deploy-HelmCharts -Path "test-helm-config.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false
+
+            Should -Invoke -CommandName Write-Warning -ParameterFilter { $Message -like "*Chart is not enabled*" } -Times 1
+        }
+
+        It "will deploy only specified charts when Names parameter is provided" {
+            Mock -CommandName Write-Warning -MockWith {} -Verifiable
+
+            Deploy-HelmCharts -Path "test-helm-config.yaml" -Names @("nginx-ingress") -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false
+
+            Should -Invoke -CommandName Write-Warning -ParameterFilter { $Message -like "*Skipping chart due to names list*" } -Times 2
+        }
+
+        It "will skip charts not matching the cloud platform" {
+            Mock -CommandName Write-Warning -MockWith {} -Verifiable
+            $env:CLOUD_PLATFORM = "azure"
+
+            Deploy-HelmCharts -Path "test-helm-config.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false
+
+            Should -Invoke -CommandName Write-Warning -ParameterFilter { $Message -like "*Chart is not for this cloud platform*" } -Times 1
+        }
+    }
+
+    Context "Helm command execution" {
+
+        BeforeAll {
+            # Create a simple test configuration
+            $testConfig = @"
+charts:
+  - name: test-chart
+    enabled: true
+    location: stable
+    repo: https://charts.example.com
+    namespace: test-namespace
+    version: 1.0.0
+    release_name: my-release
+"@
+            Set-Content -Path "test-helm-simple.yaml" -Value $testConfig
+        }
+
+        AfterAll {
+            Remove-Item -Path "test-helm-simple.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will add helm repository when repo is specified" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-helm-simple.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*Invoke-Helm -Repo*" } -Times 1
+        }
+
+        It "will use release_name when provided" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-helm-simple.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*-releasename my-release*" } -Times 1
+        }
+
+        It "will use chart name as release name when release_name is not provided" {
+            $testConfig = @"
+charts:
+  - name: test-chart
+    enabled: true
+    location: stable
+    namespace: default
+"@
+            Set-Content -Path "test-helm-norelease.yaml" -Value $testConfig
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-helm-norelease.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*-releasename test-chart*" } -Times 1
+
+            Remove-Item -Path "test-helm-norelease.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will include chart version when specified" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-helm-simple.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*-chartversion 1.0.0*" } -Times 1
+        }
+    }
+
+    Context "Dry run functionality" {
+
+        BeforeAll {
+            $testConfig = @"
+charts:
+  - name: nginx
+    enabled: true
+    location: stable
+    namespace: default
+"@
+            Set-Content -Path "test-dryrun.yaml" -Value $testConfig
+            Mock -CommandName Write-Host -MockWith {}
+        }
+
+        AfterAll {
+            Remove-Item -Path "test-dryrun.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will output commands when Dryrun is specified" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-dryrun.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*Invoke-Helm*" } -Times 1
+        }
+
+        It "will not invoke expressions during dry run" {
+            Mock -CommandName Invoke-Expression -MockWith {}
+
+            Deploy-HelmCharts -Path "test-dryrun.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Invoke-Expression -Times 0
+        }
+    }
+
+    Context "Values template expansion" {
+
+        BeforeAll {
+            # Create test values template
+            $valuesTemplate = @"
+replicaCount: 3
+image:
+  repository: test-repo
+  tag: latest
+"@
+            Set-Content -Path "test-values.yaml" -Value $valuesTemplate
+
+            $testConfig = @"
+charts:
+  - name: test-with-values
+    enabled: true
+    location: stable
+    namespace: default
+    values_template: test-values.yaml
+"@
+            Set-Content -Path "test-values-config.yaml" -Value $testConfig
+        }
+
+        AfterAll {
+            Remove-Item -Path "test-values.yaml" -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path "test-values-config.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will expand values template when specified" {
+            Deploy-HelmCharts -Path "test-values-config.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Expand-Template -Times 2  # Once for config, once for values
+        }
+
+        It "will include valuepath in helm command when values template exists" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-values-config.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*-valuepath*" } -Times 1
+        }
+
+        It "will warn if values template file cannot be found" {
+            $testConfig = @"
+charts:
+  - name: test-missing-values
+    enabled: true
+    location: stable
+    namespace: default
+    values_template: missing-file.yaml
+"@
+            Set-Content -Path "test-missing-values.yaml" -Value $testConfig
+            Mock -CommandName Write-Warning -MockWith {} -Verifiable
+
+            Deploy-HelmCharts -Path "test-missing-values.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false
+
+            Should -Invoke -CommandName Write-Warning -ParameterFilter { $Message -like "*Values template file cannnot be found*" } -Times 1
+
+            Remove-Item -Path "test-missing-values.yaml" -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Raw YAML wrapping" {
+
+        BeforeAll {
+            $testConfig = @"
+charts:
+  - name: raw-manifest
+    enabled: true
+    location: https://example.com/manifest.yaml
+    wrap_raw_yaml: true
+    namespace: default
+"@
+            Set-Content -Path "test-raw-yaml.yaml" -Value $testConfig
+            Mock -CommandName Add-Content -MockWith {}
+        }
+
+        AfterAll {
+            Remove-Item -Path "test-raw-yaml.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will download and wrap raw YAML when wrap_raw_yaml is true" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-raw-yaml.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Invoke-WebRequest -Times 1
+            Should -Invoke -CommandName Add-Content -ParameterFilter { $Path -like "*Chart.yaml" } -Times 1
+        }
+    }
+
+    Context "Rollout status checks" {
+
+        BeforeAll {
+            $testConfig = @"
+charts:
+  - name: chart-with-rollout
+    enabled: true
+    location: stable
+    namespace: default
+    rollout_checks:
+      - name: deployment/test-deployment
+        timeout: 120s
+        namespace: default
+"@
+            Set-Content -Path "test-rollout.yaml" -Value $testConfig
+        }
+
+        AfterAll {
+            Remove-Item -Path "test-rollout.yaml" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "will execute rollout status checks when specified" {
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-rollout.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*kubectl rollout status*" } -Times 1
+        }
+
+        It "will use default timeout if not specified in rollout check" {
+            $testConfig = @"
+charts:
+  - name: chart-default-timeout
+    enabled: true
+    location: stable
+    namespace: default
+    rollout_checks:
+      - name: deployment/test
+"@
+            Set-Content -Path "test-rollout-default.yaml" -Value $testConfig
+            Mock -CommandName Write-Host -MockWith {}
+
+            Deploy-HelmCharts -Path "test-rollout-default.yaml" -Provider "azure" -Identifier "test-rg" -ClusterName "test-cluster" -K8sAuthRequired $false -Dryrun
+
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*--timeout 60s*" } -Times 1
+
+            Remove-Item -Path "test-rollout-default.yaml" -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
@@ -52,13 +52,11 @@ function Deploy-HelmCharts() {
 		$Provider = $env:CLOUD_PROVIDER,
 
 		[string]
-		[Alias("ResourceGroup")]
 		# Identifier for finding the cluster
 		# In the case of Azure this is the resource group name
 		$Identifier,
 
 		[string]
-		[Alias("aksname")]
 		# Name of the cluster
 		$ClusterName,
 

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
@@ -39,7 +39,7 @@ function Deploy-HelmCharts() {
 
 		[string[]]
 		# Names of charts that should be deployed.
-		# This does not override the enabled flag, but allows a subset of enabled chartts
+		# This does not override the enabled flag, but allows a subset of enabled charts
 		# to be deployed
 		$Names,
 

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
@@ -110,7 +110,7 @@ function Deploy-HelmCharts() {
 	# Iterate around all the charts in the object
 	foreach ($chart in $helm.charts)
 	{
-		# if any names have been specified only run if the current chart is in that list
+		# If any names have been specified only run if the current chart is in that list
 		if ($Names.length -gt 0 -and $Names -notcontains $chart.name)
 		{
 			Write-Warning -Message ("Skipping chart due to names list: {0} not in [{1}]" -f $chart.name, ($Names -join ","))

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
@@ -158,7 +158,7 @@ function Deploy-HelmCharts() {
 			}
 		}
 
-		# if `wrap_raw_yaml` is true then download YAML file and wrap in a dummy chart
+		# If `wrap_raw_yaml` is true then download YAML file and wrap in a dummy chart
 		if (! [String]::IsNullOrEmpty($chart.wrap_raw_yaml) -and $chart.wrap_raw_yaml -eq $true)
 		{
 			if (Test-Path -Path "${Tempdir}/$($chart.name)")

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
@@ -1,0 +1,287 @@
+function Deploy-HelmCharts() {
+
+	<#
+
+		.SYNOPSIS
+		Deploy Helm charts to a Kubernetes cluster based on a configuration file
+
+		.DESCRIPTION
+		Reads a configuration file specifying which Helm charts should be deployed to a Kubernetes cluster.
+		The function supports deploying charts from repositories or wrapping raw YAML files as Helm charts.
+		
+		It can authenticate to Azure AKS or AWS EKS clusters, expand templates with environment variable
+		substitution, and perform rollout status checks after deployment.
+
+		The configuration file can specify enabled/disabled charts, cloud platform filtering, custom values
+		templates, and deployment parameters for each chart.
+
+		.EXAMPLE
+
+		Deploy-HelmCharts -Path deploy/helm/k8s_apps.yaml -Provider azure -Identifier myResourceGroup -ClusterName myAKSCluster
+
+		This will read the configuration from the specified file and deploy all enabled Helm charts to the
+		Azure AKS cluster named myAKSCluster in the resource group myResourceGroup.
+
+		.EXAMPLE
+
+		Deploy-HelmCharts -Names @("nginx-ingress", "cert-manager") -Dryrun
+
+		This will perform a dry run showing what commands would be executed to deploy only the nginx-ingress
+		and cert-manager charts that are enabled in the default configuration file.
+
+	#>
+
+	[CmdletBinding()]
+	param (
+		[string]
+		# Path to the configuration file stating which charts should be deployed
+		$Path = $env:HELM_CHARTS,
+
+		[string[]]
+		# Names of charts that should be deployed.
+		# This does not override the enabled flag, but allows a subset of enabled chartts
+		# to be deployed
+		$Names,
+
+		[string]
+		# Path to temporary directory for writing out templates
+		$Tempdir = "tmp/",
+
+		[string]
+		# Cloud provider being targeted
+		$Provider = $env:CLOUD_PROVIDER,
+
+		[string]
+		[Alias("ResourceGroup")]
+		# Identifier for finding the cluster
+		# In the case of Azure this is the resource group name
+		$Identifier,
+
+		[string]
+		[Alias("aksname")]
+		# Name of the cluster
+		$ClusterName,
+
+		[bool]
+		$K8sAuthRequired = $true,
+
+		[switch]
+		# Specify a dryrun, which will output the helm command to run
+		$Dryrun
+	)
+
+	# Set defaults on undefined parameters
+	if ([String]::IsNullOrEmpty($Path))
+	{
+		$path = [IO.Path]::Join("deploy", "helm", "k8s_apps.yaml")
+	}
+
+	# Check to see if the path exists
+	if (! (Test-Path -Path $path))
+	{
+		Write-Error ("Specified file cannot be located: {0}" -f $path)
+		return
+	}
+
+	# Determine if the tempdir path exists, if not create it
+	if (! (Test-Path -Path $Tempdir))
+	{
+		Write-Information ("Creating temporary dir: {0}" -f $Tempdir)
+		New-Item -Type Directory -Path $Tempdir | Out-Null
+	}
+
+	# Read in the configuration, replacing parameters as necessary
+	$template_name = Split-Path -Path $path -Leaf
+	$target = [IO.Path]::Join($Tempdir, $template_name)
+
+	# Expand the template for the values
+	$template = Get-Content -Path $path -Raw
+	if ([String]::IsNullOrEmpty($template))
+	{
+		New-Item -Type File -Path $target -Force | Out-Null
+	}
+	else
+	{
+		Expand-Template -Template $template -Target $target
+	}
+
+	$helm = Get-Content -Path $target -Raw | ConvertFrom-Yaml
+
+	Write-Host $(Get-Content -Path $target -Raw)
+
+	# Iterate around all the charts in the object
+	foreach ($chart in $helm.charts)
+	{
+		# if any names have been specified only run if the current chart is in that list
+		if ($Names.length -gt 0 -and $Names -notcontains $chart.name)
+		{
+			Write-Warning -Message ("Skipping chart due to names list: {0} not in [{1}]" -f $chart.name, ($Names -join ","))
+		}
+
+		# Skip the chart if not enabled
+		if (! $chart.enabled)
+		{
+			Write-Warning -Message ("Chart is not enabled, skpping: {0}" -f $chart.name)
+			continue
+		}
+
+		# Skip chart if it is not for this current cloud platform
+		if ($chart.clouds.length -gt 0 -and $chart.clouds -notcontains $env:CLOUD_PLATFORM)
+		{
+			Write-Warning -Message ("Chart is not for this cloud platform: {0}" -f $env:CLOUD_PLATFORM)
+			continue
+		}
+
+		# Check if the values_template file exists
+		if (! [String]::IsNullOrEmpty($chart.values_template) -and !(Test-Path -Path $chart.values_template))
+		{
+			Write-Warning -Message ("Values template file cannnot be found: {0}" -f $chart.values_template)
+			continue
+		}
+
+		$namespace = "default"
+		if (! [String]::IsNullOrEmpty($chart.namespace))
+		{
+			$namespace = $chart.namespace
+		}
+
+		# If a repo has been set, run the command to add the repo to helm
+		if (! [String]::IsNullOrEmpty($chart.repo))
+		{
+			$command = "Invoke-Helm -Repo -RepositoryName {0} -RepositoryUrl {1}" -f $chart.location, $chart.repo
+
+			if ($Dryrun)
+			{
+				Write-Host $command
+			}
+			else
+			{
+				Invoke-Expression $command
+			}
+		}
+
+		# if `wrap_raw_yaml` is true then download YAML file and wrap in a dummy chart
+		if (! [String]::IsNullOrEmpty($chart.wrap_raw_yaml) -and $chart.wrap_raw_yaml -eq $true)
+		{
+			if (Test-Path -Path "${Tempdir}/$($chart.name)")
+			{
+				Remove-Item -Path "${Tempdir}/$($chart.name)" -Recurse
+			}
+
+			New-Item -ItemType "Directory" -Path $Tempdir -Name $chart.name
+			New-Item -ItemType "Directory" -Path "${Tempdir}/$($chart.name)" -Name templates
+			$chartYaml = @"
+apiVersion: v2
+name: $($chart.name)
+description: A chart wrapper for single raw YAML files. Check the deployed resources for more information.
+
+type: application
+
+version: 0.0.1
+"@
+			Add-Content -Path "${Tempdir}/$($chart.name)/Chart.yaml" -Value $chartYaml
+			Add-Content -Path "${Tempdir}/$($chart.name)/values.yaml" -Value ""
+			Invoke-WebRequest $chart.location -OutFile "${Tempdir}/$($chart.name)/templates/main.yaml"
+
+			$chart.location = $Tempdir
+			$chart.values_template = "${Tempdir}/$($chart.name)/values.yaml"
+		}
+
+		$authToK8s = $K8sAuthRequired
+
+		# Configure an array to hold the pareameters for the helm cmdlet
+		$helm_args = @()
+		$helm_args += "-install"
+		$helm_args += "-chartpath `"{0}/{1}`"" -f $chart.location, $chart.name
+		$helm_args += "-identifier {0}" -f $Identifier
+		$helm_args += "-target {0}" -f $ClusterName
+		$helm_args += "-namespace {0}" -f $namespace
+		$helm_args += "-provider {0}" -f $Provider
+		$helm_args += "-k8sauthrequired `${0}" -f $authToK8s
+
+		# Only Auth to K8s once
+		if ($true -eq $authToK8s)
+		{
+			$authToK8s = $false
+		}
+
+		if (! [String]::IsNullOrEmpty($chart.version))
+		{
+			$helm_args += "-chartversion {0}" -f $chart.version
+		}
+
+		# Determine the release name
+		$release_name = $chart.release_name
+		if ([String]::IsNullOrEmpty($release_name))
+		{
+			$release_name = $chart.name
+		}
+		$release_name = ($release_name -replace " |_", "-").ToLower()
+		$helm_args += "-releasename {0}" -f $release_name
+
+		# Determime the path for the rendered template
+		# Only if a values template has been specified
+		if (! [String]::IsNullOrEmpty($chart.values_template))
+		{
+			$template_name = Split-Path -Path $chart.values_template -Leaf
+			$target = [IO.Path]::Join($Tempdir, $template_name)
+
+			# Expand the template for the values
+			$template = Get-Content -Path $chart.values_template -Raw
+			if ([String]::IsNullOrEmpty($template))
+			{
+				New-Item -Type File -Path $target -Force | Out-Null
+			}
+			else
+			{
+				Expand-Template -Template $template -Target $target
+			}
+
+			$helm_args += "-valuepath {0}" -f $target
+		}
+
+		# Build up the command to run
+		$command = "Invoke-Helm {0}" -f ($helm_args -join " ")
+
+		Write-Host ("DEPLOYING: '{0}/{1}'" -f $chart.location, $chart.name)
+
+		if ($Dryrun)
+		{
+			Write-Host $command
+		}
+		else
+		{
+			Invoke-Expression $command
+		}
+
+		if (! [String]::IsNullOrEmpty($chart.rollout_checks))
+		{
+			# Build up Rollout Status checks command to run
+			$rolloutBaseCommand = "kubectl rollout status -n {0} --timeout {1} {2}"
+
+			foreach ($rolloutCheck in $chart.rollout_checks)
+			{
+				$namespace = [String]::IsNullOrEmpty($rolloutCheck.namespace) ? $chart.namespace : $rolloutCheck.namespace
+				$timeout = [String]::IsNullOrEmpty($rolloutCheck.timeout) ? '60s' : $rolloutCheck.timeout
+				$rolloutCommand = $rolloutBaseCommand -f $namespace, $timeout, $rolloutCheck.name
+
+				if ($Dryrun)
+				{
+					Write-Host $rolloutCommand
+				}
+				else
+				{
+					Invoke-Expression $rolloutCommand
+
+					if ($LASTEXITCODE -ne 0)
+					{
+						throw "DEPLOYING FAILED: Failed to run command '${rolloutCommand}' in the rollout status checks for '{0}{1}'..." -f $chart.location, $chart.name
+					}
+				}
+			}
+		}
+
+		Write-Host ("DEPLOYING FINISHED: '{0}/{1}'`n`n" -f $chart.location, $chart.name)
+	}
+
+}

--- a/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
+++ b/src/modules/EnsonoBuild/exported/Deploy-HelmCharts.ps1
@@ -168,6 +168,18 @@ function Deploy-HelmCharts() {
 				Remove-Item -Path "${Tempdir}/$($chart.name)" -Recurse
 			}
 
+			$chartVersion = "0.0.1"
+
+			if (! [String]::IsNullOrEmpty($chart.versioning_regex))
+			{
+				$match = $chart.location -match $chart.versioning_regex
+
+				if ($match -eq $true)
+				{
+					$chartVersion = $Matches[1]
+				}
+			}
+
 			New-Item -ItemType "Directory" -Path $Tempdir -Name $chart.name
 			New-Item -ItemType "Directory" -Path "${Tempdir}/$($chart.name)" -Name templates
 			$chartYaml = @"
@@ -177,7 +189,7 @@ description: A chart wrapper for single raw YAML files. Check the deployed resou
 
 type: application
 
-version: 0.0.1
+version: ${chartVersion}
 "@
 			Add-Content -Path "${Tempdir}/$($chart.name)/Chart.yaml" -Value $chartYaml
 			Add-Content -Path "${Tempdir}/$($chart.name)/values.yaml" -Value ""

--- a/src/modules/EnsonoBuild/exported/New-EnvConfig.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/New-EnvConfig.Tests.ps1
@@ -61,6 +61,13 @@ stages:
 
     Context "Create script" {
 
+        BeforeEach {
+            # Ensure SHELL env var is not set for PowerShell tests
+            if (Test-Path env:\SHELL) {
+                Remove-Item env:\SHELL
+            }
+        }
+
         It "will create a PowerShell script with vars - Azure" {
 
             New-EnvConfig -Path $stageVarFile -ScriptPath $testfolder -Cloud Azure -Stage pester

--- a/src/modules/EnsonoBuild/exported/New-EnvConfig.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/New-EnvConfig.Tests.ps1
@@ -99,7 +99,7 @@ stages:
 
             New-EnvConfig -Path $stageVarFile -ScriptPath $testfolder -Cloud AWS -Stage pester
 
-            $scriptPath = [IO.Path]::Combine($testFolder, "envvar-azure-pester.ps1")
+            $scriptPath = [IO.Path]::Combine($testFolder, "envvar-aws-pester.ps1")
 
             # Check that the script has been created
             Test-Path -Path $scriptPath | Should -BeTrue
@@ -115,7 +115,7 @@ stages:
 
             New-EnvConfig -Path $stageVarFile -ScriptPath $testfolder -Cloud AWS -Stage pester
 
-            $scriptPath = [IO.Path]::Combine($testFolder, "envvar-azure-pester.sh")
+            $scriptPath = [IO.Path]::Combine($testFolder, "envvar-aws-pester.sh")
 
             # Check that the script has been created
             Test-Path -Path $scriptPath | Should -BeTrue


### PR DESCRIPTION
## 📲 What
Introduces a new PowerShell function, `Deploy-HelmCharts` enabling automated deployment of Helm charts to Kubernetes clusters based on configuration files.

This script has been used in a lot projects and usually sits in the clients repo

This is now included as part of the independent runner

Fixed the test failures for New-EnvConfig.ps1 as that was blocking the pipeline

## 🤔 Why

Used to deploy multiple helm charts
