### PR TITLE
Add Terraform Test to `Invoke-Terraform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Indepenent Runner
+# Ensono Independent Runner
 
-This repository contains the documentation on how the Amido Independent Runner is expected to work. It also contains the PowerShell module that is used in each of the pipelines that use the Independent Runner.
+This repository contains the documentation on how the Ensono Independent Runner is expected to work. It also contains the PowerShell module that is used in each of the pipelines that use the Independent Runner.
 
 ## Running Tests
 
-Test should be run in another instance of Pwsh as there are Tests that modify
+Tests should be run in another instance of Pwsh as there are Tests that modify
 environment variables and don't always set them back.
 
 An example safe invocation is:

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -348,12 +348,36 @@ Describe "Invoke-Terraform" {
     }
 
     Context "Test" {
-        It "will run terraform test with no filter" {
+        It "will run terraform init and test with no filter" {
             Mock `
                 -Command Invoke-External `
                 -Verifiable `
                 -MockWith { } `
-                -ParameterFilter { $commands -eq "terraform test" }
+                -ParameterFilter { (Compare-Object -ReferenceObject $commands -DifferenceObject @("terraform init -backend=false", "terraform test")).length -eq 0 }
+
+            Mock `
+                -Command Test-Path `
+                -Verifiable `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform" }
+
+            Mock `
+                -Command Remove-Item `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform" -and $Recurse.IsPresent -and $Force.IsPresent }
+
+            Mock `
+                -Command Test-Path `
+                -Verifiable `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" }
+
+            Mock `
+                -Command Remove-Item `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" -and $Recurse.IsPresent -and $Force.IsPresent }
 
             Invoke-Terraform -test
 
@@ -361,12 +385,36 @@ Describe "Invoke-Terraform" {
             Should -Invoke Invoke-External -Exactly 1
         }
 
-        It "will run terraform test with a filter for specific test files" {
+        It "will run terraform init and test with a filter for specific test files" {
             Mock `
                 -Command Invoke-External `
                 -Verifiable `
                 -MockWith { } `
-                -ParameterFilter { $commands -eq "terraform test -filter=tests/main.tftest.hcl" }
+                -ParameterFilter { (Compare-Object -ReferenceObject $commands -DifferenceObject @("terraform init -backend=false", "terraform test -filter=tests/main.tftest.hcl")).length -eq 0 }
+
+            Mock `
+                -Command Test-Path `
+                -Verifiable `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform" }
+
+            Mock `
+                -Command Remove-Item `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform" -and $Recurse.IsPresent -and $Force.IsPresent }
+
+            Mock `
+                -Command Test-Path `
+                -Verifiable `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" }
+
+            Mock `
+                -Command Remove-Item `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" -and $Recurse.IsPresent -and $Force.IsPresent }
 
             Invoke-Terraform -test -filter "tests/main.tftest.hcl"
 
@@ -374,17 +422,78 @@ Describe "Invoke-Terraform" {
             Should -Invoke Invoke-External -Exactly 1
         }
 
-        It "will run terraform test with a filter and additional arguments" {
+        It "will run terraform init and test with a filter and additional arguments" {
             Mock `
                 -Command Invoke-External `
                 -Verifiable `
                 -MockWith { } `
-                -ParameterFilter { $commands -eq "terraform test -filter=tests/main.tftest.hcl -verbose" }
+                -ParameterFilter { (Compare-Object -ReferenceObject $commands -DifferenceObject @("terraform init -backend=false", "terraform test -filter=tests/main.tftest.hcl -verbose")).length -eq 0 }
+
+            Mock `
+                -Command Test-Path `
+                -Verifiable `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform" }
+
+            Mock `
+                -Command Remove-Item `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform" -and $Recurse.IsPresent -and $Force.IsPresent }
+
+            Mock `
+                -Command Test-Path `
+                -Verifiable `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" }
+
+            Mock `
+                -Command Remove-Item `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" -and $Recurse.IsPresent -and $Force.IsPresent }
 
             Invoke-Terraform -test -filter "tests/main.tftest.hcl" -arguments "-verbose"
 
             Should -InvokeVerifiable
             Should -Invoke Invoke-External -Exactly 1
+        }
+
+        It "will not append TF_BACKEND environment variable to terraform test" {
+            $env:TF_BACKEND = "key=tfstate,access_key=123456"
+
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { (Compare-Object -ReferenceObject $commands -DifferenceObject @("terraform init -backend=false", "terraform test")).length -eq 0 }
+
+            Mock `
+                -Command Test-Path `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform" }
+
+            Mock `
+                -Command Remove-Item `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform" -and $Recurse.IsPresent -and $Force.IsPresent }
+
+            Mock `
+                -Command Test-Path `
+                -MockWith { return $true } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" }
+
+            Mock `
+                -Command Remove-Item `
+                -MockWith { } `
+                -ParameterFilter { $Path -eq ".terraform.lock.hcl" -and $Recurse.IsPresent -and $Force.IsPresent }
+
+            Invoke-Terraform -test
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+
+            Remove-Item Env:\TF_BACKEND
         }
     }
 

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -347,6 +347,47 @@ Describe "Invoke-Terraform" {
         }
     }
 
+    Context "Test" {
+        It "will run terraform test with no filter" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $commands -eq "terraform test" }
+
+            Invoke-Terraform -test
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+        }
+
+        It "will run terraform test with a filter for specific test files" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $commands -eq "terraform test -filter=tests/main.tftest.hcl" }
+
+            Invoke-Terraform -test -filter "tests/main.tftest.hcl"
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+        }
+
+        It "will run terraform test with a filter and additional arguments" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { $commands -eq "terraform test -filter=tests/main.tftest.hcl -verbose" }
+
+            Invoke-Terraform -test -filter "tests/main.tftest.hcl" -arguments "-verbose"
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+        }
+    }
+
     Context "Validate" {
         It "will run the commands to perform validation checks" {
             Mock `

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -495,6 +495,49 @@ Describe "Invoke-Terraform" {
 
             Remove-Item Env:\TF_BACKEND
         }
+
+        It "will error when -fullInit is used without backend arguments" {
+            Mock `
+                -Command Invoke-External `
+                -MockWith { }
+
+            Invoke-Terraform -test -fullInit
+
+            Should -Invoke Write-Error -Exactly 1 -ParameterFilter { $Message -like "No properties have been specified for the backend*" -and $ErrorAction -eq "Stop" }
+            Should -Invoke Invoke-External -Exactly 0
+        }
+
+        It "will run terraform init with backend config and test when -fullInit is specified" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { (Compare-Object -ReferenceObject $commands -DifferenceObject @("terraform init -backend-config='key=tfstate' -backend-config='access_key=123456'", "terraform test")).length -eq 0 }
+
+            Mock -Command Remove-Item -MockWith { }
+
+            Invoke-Terraform -test -fullInit -arguments "key=tfstate,access_key=123456"
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+            Should -Invoke Remove-Item -Exactly 0
+        }
+
+        It "will run terraform init with backend config and test with filter when -fullInit is specified" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { } `
+                -ParameterFilter { (Compare-Object -ReferenceObject $commands -DifferenceObject @("terraform init -backend-config='key=tfstate' -backend-config='access_key=123456'", "terraform test -filter=tests/main.tftest.hcl")).length -eq 0 }
+
+            Mock -Command Remove-Item -MockWith { }
+
+            Invoke-Terraform -test -fullInit -filter "tests/main.tftest.hcl" -arguments "key=tfstate,access_key=123456"
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+            Should -Invoke Remove-Item -Exactly 0
+        }
     }
 
     Context "Validate" {

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -35,6 +35,16 @@ function Invoke-Terraform() {
     the name and value of the output. This is then piped to Out-File which means that the data will be save to the
     named file for use with other commands.
 
+    .EXAMPLE
+    Invoke-Terraform -test
+
+    Run all Terraform test files (*.tftest.hcl) in the current directory. Requires Terraform >= 1.6.0.
+
+    .EXAMPLE
+    Invoke-Terraform -test -filter "tests/main.tftest.hcl"
+
+    Run only the specified Terraform test file. The -filter parameter is passed directly to `terraform test -filter=`.
+
     #>
 
     [CmdletBinding()]

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -9,7 +9,7 @@ function Invoke-Terraform() {
     Terraform as required
 
     .DESCRIPTION
-    The Independent Runner uses Terraform to built up the resources that are required, primairly for ED Stacks,
+    The Independent Runner uses Terraform to build up the resources that are required, primarily for Ensono Stacks,
     but can be for any Terraform defined infrastructure.
 
     It is a wrapper for the Terraform command and will generate the necessary command from the inputs that the
@@ -19,26 +19,26 @@ function Invoke-Terraform() {
     .EXAMPLE
     Invoke-Terraform -init -arguments "false"
 
-    Initialise the Terraform files with a fase backend. This is useful for validation.
+    Initialise the Terraform files with a false backend. This is useful for validation.
 
     .EXAMPLE
     Invoke-Terraform -plan properties "-input=false", "-out=tf.plan"
 
     Plan the Terraform deployment using the files in the current directory. The properties that have been passed
-    are appended directly to the end of the Terraform command. In this example no missing inputs are requests and
+    are appended directly to the end of the Terraform command. In this example no missing inputs are requested and
     the plan is written out to the `tf.plan` file.
 
     .EXAMPLE
     Invoke-Terraform -output -path src/terraform -yaml | Out-File tfoutput.yaml
 
     This command will get the outputs from the Terraform state and output them as Yaml format. It will only output
-    the name and value of the output. This is then piped to Out-File which means that the data will be save to the
+    the name and value of the output. This is then piped to Out-File which means that the data will be saved to the
     named file for use with other commands.
 
     .EXAMPLE
     Invoke-Terraform -test
 
-    Run all Terraform test files (*.tftest.hcl) in the current directory. Requires Terraform >= 1.6.0.
+    Run all Terraform test files (*.tftest.hcl) in the current directory.
 
     .EXAMPLE
     Invoke-Terraform -test -filter "tests/main.tftest.hcl"

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -101,6 +101,20 @@ function Invoke-Terraform() {
         $yaml,
 
         [Parameter(
+            ParameterSetName = "test"
+        )]
+        [switch]
+        # Run Terraform tests
+        $test,
+
+        [Parameter(
+            ParameterSetName = "test"
+        )]
+        [string]
+        # Filter expression to select specific test files
+        $filter,
+
+        [Parameter(
             ParameterSetName = "validate"
         )]
         [switch]
@@ -308,6 +322,22 @@ function Invoke-Terraform() {
                     $data | ConvertTo-Json -Depth $JsonDepth -Compress
                 }
             }
+        }
+
+        # Run Terraform tests
+        "test" {
+
+            $command = "{0} test" -f $terraform
+
+            if (![string]::IsNullOrEmpty($filter)) {
+                $command += " -filter={0}" -f $filter
+            }
+
+            if ($arguments.Count -gt 0 -and ![String]::IsNullOrEmpty($arguments[0])) {
+                $command += " {0}" -f ($arguments -join " ")
+            }
+
+            Invoke-External -Command $command
         }
 
         # Valiate the templates

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -45,6 +45,12 @@ function Invoke-Terraform() {
 
     Run only the specified Terraform test file. The -filter parameter is passed directly to `terraform test -filter=`.
 
+    .EXAMPLE
+    Invoke-Terraform -test -fullInit -arguments "container_name=tfstate","key=my.tfstate"
+
+    Run Terraform tests with a full backend init. This is useful when test files contain `run` blocks
+    with `command = apply` that require real infrastructure and a configured backend.
+
     #>
 
     [CmdletBinding()]
@@ -123,6 +129,14 @@ function Invoke-Terraform() {
         [string]
         # Filter expression to select specific test files
         $filter,
+
+        [Parameter(
+            ParameterSetName = "test"
+        )]
+        [switch]
+        # Perform a full init with backend config instead of -backend=false.
+        # Use when tests contain run blocks with command = apply.
+        $fullInit,
 
         [Parameter(
             ParameterSetName = "validate"
@@ -343,13 +357,25 @@ function Invoke-Terraform() {
                 $testCommand += " -filter={0}" -f $filter
             }
 
-            if ($PSBoundParameters.ContainsKey('arguments') -and $arguments.Count -gt 0 -and ![String]::IsNullOrEmpty($arguments[0])) {
+            if (!$fullInit -and $PSBoundParameters.ContainsKey('arguments') -and $arguments.Count -gt 0 -and ![String]::IsNullOrEmpty($arguments[0])) {
                 $testCommand += " {0}" -f ($arguments -join " ")
             }
 
-            # Run init with false backend before running tests
+            # Build init command based on whether full backend init is requested
             $commands = @()
-            $commands += "{0} init -backend=false" -f $terraform
+            if ($fullInit) {
+                if ($arguments.Count -eq 0 -or ($arguments.Count -eq 1 -and [String]::IsNullOrEmpty($arguments[0]))) {
+                    Write-Error -Message "No properties have been specified for the backend. -fullInit requires backend arguments." -ErrorAction Stop
+                    return
+                }
+                $a = @()
+                foreach ($arg in $arguments) {
+                    $a += "-backend-config='{0}'" -f $arg
+                }
+                $commands += "{0} init {1}" -f $terraform, ($a -join " ")
+            } else {
+                $commands += "{0} init -backend=false" -f $terraform
+            }
             $commands += $testCommand
 
             Invoke-External -Command $commands
@@ -357,14 +383,16 @@ function Invoke-Terraform() {
             # After tests have run, delete the terraform dir and lock file
             # This is so that it does not interfere with the deployment of the infrastructure
             # when a valid backend is initialised
-            Write-Information -MessageData "Removing Terraform init files for 'false' backend"
-            $removals = @(
-                ".terraform",
-                ".terraform.lock.hcl"
-            )
-            foreach ($item in $removals) {
-                if (Test-Path -Path $item) {
-                    Remove-Item -Path $item -Recurse -Force
+            if (!$fullInit) {
+                Write-Information -MessageData "Removing Terraform init files for 'false' backend"
+                $removals = @(
+                    ".terraform",
+                    ".terraform.lock.hcl"
+                )
+                foreach ($item in $removals) {
+                    if (Test-Path -Path $item) {
+                        Remove-Item -Path $item -Recurse -Force
+                    }
                 }
             }
         }

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -337,17 +337,36 @@ function Invoke-Terraform() {
         # Run Terraform tests
         "test" {
 
-            $command = "{0} test" -f $terraform
+            $testCommand = "{0} test" -f $terraform
 
             if (![string]::IsNullOrEmpty($filter)) {
-                $command += " -filter={0}" -f $filter
+                $testCommand += " -filter={0}" -f $filter
             }
 
-            if ($arguments.Count -gt 0 -and ![String]::IsNullOrEmpty($arguments[0])) {
-                $command += " {0}" -f ($arguments -join " ")
+            if ($PSBoundParameters.ContainsKey('arguments') -and $arguments.Count -gt 0 -and ![String]::IsNullOrEmpty($arguments[0])) {
+                $testCommand += " {0}" -f ($arguments -join " ")
             }
 
-            Invoke-External -Command $command
+            # Run init with false backend before running tests
+            $commands = @()
+            $commands += "{0} init -backend=false" -f $terraform
+            $commands += $testCommand
+
+            Invoke-External -Command $commands
+
+            # After tests have run, delete the terraform dir and lock file
+            # This is so that it does not interfere with the deployment of the infrastructure
+            # when a valid backend is initialised
+            Write-Information -MessageData "Removing Terraform init files for 'false' backend"
+            $removals = @(
+                ".terraform",
+                ".terraform.lock.hcl"
+            )
+            foreach ($item in $removals) {
+                if (Test-Path -Path $item) {
+                    Remove-Item -Path $item -Recurse -Force
+                }
+            }
         }
 
         # Valiate the templates


### PR DESCRIPTION
## 📲 What

This pull request introduces support for running Terraform tests via the `Invoke-Terraform` function, along with several documentation improvements and typo corrections. The main focus is on enabling the execution of `terraform test` commands, including filtering specific test files and passing additional arguments.

**Terraform test support:**

* Added new `-test` and `-filter` parameters to `Invoke-Terraform`, enabling users to run all or specific Terraform test files using `terraform test`, with optional additional arguments.
* Updated the help documentation and examples in `Invoke-Terraform.ps1` to describe the new test functionality.

**Testing enhancements:**

* Added new Pester tests in `Invoke-Terraform.Tests.ps1` to verify the correct execution of `terraform test` commands, including scenarios with and without filters and additional arguments.

**Documentation and typo fixes:**

* Corrected typos and updated references from "Amido" to "Ensono" in `README.md` and `Invoke-Terraform.ps1` for consistency.

## 🤔 Why

Some projects are now using it in their tasks, so seemed a worthwhile addition

## 🛠 How

Updated the `Invoke-Terraform` function

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA